### PR TITLE
feat: 型安全 + sender 検証付き messaging レイヤーを追加 (#29)

### DIFF
--- a/.claude/rules/chrome-extension.md
+++ b/.claude/rules/chrome-extension.md
@@ -9,9 +9,12 @@ MV3 facts specific to this repo:
 - Dev vs. build differ in `manifest.config.ts`: the extension name is prefixed
   `[DEV] ${name}` when `command === 'serve'`, and icon filenames get a `-dev`
   suffix (`createIconFileSuffix`).
-- Messaging pattern: `chrome.runtime.sendMessage(msg, (res) => ...)` from a
-  UI surface, `chrome.runtime.onMessage.addListener((request, _, sendResponse) => ...)`
-  in the background worker — see `entrypoints/popup/popup.tsx` + `entrypoints/background/background.ts`.
+- Messaging goes through the typed layer in `src/lib/messaging/`, never
+  `chrome.runtime.sendMessage` / `onMessage` directly. Declare the contract in
+  `src/lib/messaging/messages.ts` (`defineMessage`), send with `sendMessage(name, payload)`
+  from a UI surface, and register handlers with `addMessageListeners({...})` in the
+  background worker — see `entrypoints/popup/popup.tsx` + `entrypoints/background/background.ts`.
+  The layer enforces `sender.id === chrome.runtime.id` and runtime payload guards by default.
 - Content scripts have no host HTML: create a DOM node, `document.body.prepend(root)`,
   then `createRoot(root).render(...)` — see `src/entrypoints/content/sample.tsx`.
 - A content script's `matches` and `js` entries both live in `manifest.config.ts`

--- a/.claude/rules/typescript-react.md
+++ b/.claude/rules/typescript-react.md
@@ -20,4 +20,4 @@ Conventions ESLint/Prettier/tsc cannot enforce:
 
 - Custom hooks return `[state, action] as const` (see `src/examples/hooks/useIncrement.ts`).
 - Pure utilities have explicit return types (see `src/examples/utils/calc.ts`: `(a: number, b: number): number`).
-- Name unused callback params `_` (see `background.ts`'s `onMessage` listener).
+- Name unused callback params `_` (e.g. an unused `sender` / event argument).

--- a/src/entrypoints/background/background.ts
+++ b/src/entrypoints/background/background.ts
@@ -1,6 +1,7 @@
-chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
-  console.log('listen message', request);
-  sendResponse({ message: 'send response from background', request });
-});
+import { addMessageListeners } from '../../lib/messaging/messages';
 
-export {};
+// sender 検証・payload ガードはレイヤー側が既定で行う。ここでは検証済みの
+// 型付き payload を受け取り、型付き response を返すだけでよい。
+addMessageListeners({
+  greet: (payload) => ({ reply: `Hello, ${payload.text}!` }),
+});

--- a/src/entrypoints/popup/popup.tsx
+++ b/src/entrypoints/popup/popup.tsx
@@ -1,14 +1,15 @@
 import React, { StrictMode, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { sendMessage } from '../../lib/messaging/messages';
 
 const Root = () => {
   const [response, setResponse] = useState('');
 
   const onClick = () => {
-    chrome.runtime.sendMessage('send message from popup', (res) => {
-      console.log(res);
-      setResponse(res?.message);
-    });
+    // payload / 戻り値の型は契約から推論される(型注釈不要)
+    sendMessage('greet', { text: 'popup' })
+      .then((res) => setResponse(res.reply))
+      .catch((error: unknown) => setResponse(String(error)));
   };
 
   return (

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -2,5 +2,41 @@
 
 entrypoints から利用する共有モジュールの置き場です。
 
-- messaging / storage は後続 Issue で実装予定
 - 依存方向は `entrypoints → lib` のみ許可。`lib` から `entrypoints` への import は禁止
+- storage は後続 Issue で実装予定
+
+## messaging(`src/lib/messaging/`)
+
+Extension context 間(popup / options / content ↔ background)の型安全な
+messaging レイヤー。依存ゼロの自前実装。
+
+- `createMessaging.ts` — 汎用エンジン(`createMessaging` / `defineMessage`)。触らなくてよい
+- `messages.ts` — アプリのメッセージ契約。**新しいメッセージはここに1件追加するだけ**
+
+### 使い方
+
+1. `messages.ts` の `messages` に契約を追加(request / response の実行時ガードを宣言):
+
+   ```ts
+   export const messages = {
+     greet: defineMessage(
+       (v): v is { text: string } => isRecord(v) && typeof v.text === 'string',
+       (v): v is { reply: string } => isRecord(v) && typeof v.reply === 'string',
+     ),
+   } as const;
+   ```
+
+2. 送信側(popup 等)は `sendMessage(name, payload)`。payload / 戻り値は型推論される:
+
+   ```ts
+   const res = await sendMessage('greet', { text: 'popup' }); // res: { reply: string }
+   ```
+
+3. 受信側(background)は `addMessageListeners`。検証済みの型付き payload を受け取る:
+
+   ```ts
+   addMessageListeners({ greet: (payload) => ({ reply: `Hello, ${payload.text}!` }) });
+   ```
+
+`sender.id !== chrome.runtime.id` の発信・未知メッセージ・payload ガード不合格は
+**既定で拒否**される。tabs / Port(長寿命接続)は未対応(必要時に拡張)。

--- a/src/lib/messaging/createMessaging.test.ts
+++ b/src/lib/messaging/createMessaging.test.ts
@@ -1,0 +1,162 @@
+import { createMessaging, defineMessage } from './createMessaging';
+
+const EXTENSION_ID = 'test-extension-id';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+// テスト用の最小契約(エンジンは契約に非依存なので独自契約を注入できる)
+const testMessages = {
+  greet: defineMessage(
+    (value): value is { text: string } =>
+      isRecord(value) && typeof value.text === 'string',
+    (value): value is { reply: string } =>
+      isRecord(value) && typeof value.reply === 'string',
+  ),
+} as const;
+
+type Listener = (
+  message: unknown,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void,
+) => boolean | undefined;
+
+let listeners: Listener[] = [];
+// 次に送るメッセージの sender。既定は拡張自身(検証を通る)。
+let nextSender: chrome.runtime.MessageSender = { id: EXTENSION_ID };
+
+const setupChromeMock = () => {
+  listeners = [];
+  nextSender = { id: EXTENSION_ID };
+  const chromeMock = {
+    runtime: {
+      id: EXTENSION_ID,
+      onMessage: {
+        addListener: (fn: Listener) => listeners.push(fn),
+        removeListener: (fn: Listener) => {
+          listeners = listeners.filter((registered) => registered !== fn);
+        },
+      },
+      // 登録済みリスナへ配送し、最初に sendResponse された値で resolve する。
+      sendMessage: (message: unknown) =>
+        new Promise<unknown>((resolve) => {
+          for (const listener of listeners) {
+            const keepChannelOpen = listener(message, nextSender, resolve);
+            if (keepChannelOpen) return;
+          }
+          resolve(undefined);
+        }),
+    },
+  };
+  globalThis.chrome = chromeMock as unknown as typeof chrome;
+};
+
+describe('lib/messaging/createMessaging', () => {
+  beforeEach(setupChromeMock);
+  afterEach(() => {
+    listeners = [];
+  });
+
+  it('型付き payload を送り、型付き response を受け取れる(正常往復)', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({
+      greet: (payload) => ({ reply: `Hello, ${payload.text}!` }),
+    });
+
+    await expect(sendMessage('greet', { text: 'world' })).resolves.toEqual({
+      reply: 'Hello, world!',
+    });
+  });
+
+  it('非同期ハンドラの response も受け取れる', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({
+      greet: async (payload) =>
+        Promise.resolve({ reply: `Hi ${payload.text}` }),
+    });
+
+    await expect(sendMessage('greet', { text: 'async' })).resolves.toEqual({
+      reply: 'Hi async',
+    });
+  });
+
+  it('不正な payload は既定で拒否する', async () => {
+    const { addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
+
+    // 型を迂回してガードに合致しない payload を直接送る
+    const response = await chrome.runtime.sendMessage({
+      __messageName: 'greet',
+      payload: { text: 123 },
+    });
+
+    expect(response).toEqual({
+      ok: false,
+      error: expect.stringContaining('invalid payload'),
+    });
+  });
+
+  it('sender が拡張自身でない場合は応答しない(sendMessage は throw する)', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
+
+    nextSender = { id: 'malicious-extension-id' };
+
+    await expect(sendMessage('greet', { text: 'world' })).rejects.toThrow(
+      /no valid response/,
+    );
+  });
+
+  it('未知のメッセージ名は拒否する', async () => {
+    const { addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
+
+    const response = await chrome.runtime.sendMessage({
+      __messageName: 'unknown-message',
+      payload: {},
+    });
+
+    expect(response).toEqual({
+      ok: false,
+      error: expect.stringContaining('unknown message'),
+    });
+  });
+
+  it('response がガードに合致しない場合は throw する', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({
+      // 契約に反する response を返す(型を迂回)
+      greet: () => ({ wrong: true }) as unknown as { reply: string },
+    });
+
+    await expect(sendMessage('greet', { text: 'world' })).rejects.toThrow(
+      /type guard/,
+    );
+  });
+
+  it('ハンドラが例外を投げた場合はエラー応答になり、送信側で throw する', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    addMessageListeners({
+      greet: () => {
+        throw new Error('handler boom');
+      },
+    });
+
+    await expect(sendMessage('greet', { text: 'world' })).rejects.toThrow(
+      /handler boom/,
+    );
+  });
+
+  it('戻り値の関数でリスナを登録解除できる', async () => {
+    const { sendMessage, addMessageListeners } = createMessaging(testMessages);
+    const unsubscribe = addMessageListeners({
+      greet: (payload) => ({ reply: payload.text }),
+    });
+    unsubscribe();
+
+    // リスナがいないので response は返らず throw する
+    await expect(sendMessage('greet', { text: 'world' })).rejects.toThrow(
+      /no valid response/,
+    );
+  });
+});

--- a/src/lib/messaging/createMessaging.ts
+++ b/src/lib/messaging/createMessaging.ts
@@ -1,0 +1,155 @@
+// Extension context 間の型安全 messaging レイヤー(依存ゼロ)。
+// 契約(メッセージ名 → request/response の実行時ガード)を単一ソースとし、
+// 送信側・受信側の型をガードの型述語から導出する。sender 検証と payload の
+// 実行時ガードにより、不正な送信元・不正な payload を既定で拒否する。
+//
+// 対象は chrome.runtime.sendMessage(拡張内の一往復)のみ。tabs / Port は
+// 意図的に未対応(YAGNI)。
+
+/** メッセージ1件の契約。request/response それぞれの実行時ガードを持つ。 */
+export type MessageContract<Req = unknown, Res = unknown> = {
+  isRequest: (value: unknown) => value is Req;
+  isResponse: (value: unknown) => value is Res;
+};
+
+/** メッセージ名 → 契約のマップ。 */
+export type ContractMap = Record<string, MessageContract>;
+
+/**
+ * 契約を1件宣言する。両ガードから Req / Res を推論するため、型注釈は不要。
+ * これがメッセージの型と実行時検証の単一ソースになる。
+ */
+export const defineMessage = <Req, Res>(
+  isRequest: (value: unknown) => value is Req,
+  isResponse: (value: unknown) => value is Res,
+): MessageContract<Req, Res> => ({ isRequest, isResponse });
+
+type GuardType<G> = G extends (value: unknown) => value is infer T ? T : never;
+
+/** 契約からメッセージ名の union を取り出す。 */
+export type MessageName<M extends ContractMap> = keyof M & string;
+/** 指定メッセージの request 型。 */
+export type RequestOf<M extends ContractMap, K extends keyof M> = GuardType<
+  M[K]['isRequest']
+>;
+/** 指定メッセージの response 型。 */
+export type ResponseOf<M extends ContractMap, K extends keyof M> = GuardType<
+  M[K]['isResponse']
+>;
+
+/** 受信側ハンドラマップ。登録は部分的でよい(未登録メッセージは無視)。 */
+export type MessageHandlers<M extends ContractMap> = {
+  [K in MessageName<M>]?: (
+    payload: RequestOf<M, K>,
+    sender: chrome.runtime.MessageSender,
+  ) => ResponseOf<M, K> | Promise<ResponseOf<M, K>>;
+};
+
+// --- ワイヤ形式(この2種のエンベロープ以外は未知メッセージとして無視する) ---
+
+type RequestEnvelope = { __messageName: string; payload: unknown };
+type ResponseEnvelope =
+  { ok: true; data: unknown } | { ok: false; error: string };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isRequestEnvelope = (value: unknown): value is RequestEnvelope =>
+  isRecord(value) &&
+  typeof value.__messageName === 'string' &&
+  'payload' in value;
+
+const isResponseEnvelope = (value: unknown): value is ResponseEnvelope =>
+  isRecord(value) && typeof value.ok === 'boolean';
+
+const toErrorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+/**
+ * 契約から型付きの送信ヘルパーと受信登録関数を生成する。
+ * 利用者はメッセージ契約を1箇所に書き、この戻り値を送受信で共有する。
+ */
+export const createMessaging = <M extends ContractMap>(contracts: M) => {
+  /**
+   * 型付き送信。payload / 戻り値の型は契約から推論される。
+   * response エンベロープ欠落・`ok:false`・response ガード不合格はいずれも throw。
+   */
+  const sendMessage = async <K extends MessageName<M>>(
+    name: K,
+    payload: RequestOf<M, K>,
+  ): Promise<ResponseOf<M, K>> => {
+    const envelope: RequestEnvelope = { __messageName: name, payload };
+    const response: unknown = await chrome.runtime.sendMessage(envelope);
+
+    if (!isResponseEnvelope(response)) {
+      throw new Error(`messaging: no valid response for "${name}"`);
+    }
+    if (!response.ok) {
+      throw new Error(`messaging: "${name}" was rejected: ${response.error}`);
+    }
+    if (!contracts[name].isResponse(response.data)) {
+      throw new Error(
+        `messaging: response for "${name}" failed its type guard`,
+      );
+    }
+    return response.data as ResponseOf<M, K>;
+  };
+
+  /**
+   * 型付き受信登録。onMessage リスナ内で以下を既定で拒否する:
+   * 拡張外の sender / 未知メッセージ名 / request ガード不合格。
+   * 戻り値は登録解除関数。
+   */
+  const addMessageListeners = (handlers: MessageHandlers<M>): (() => void) => {
+    const listener = (
+      message: unknown,
+      sender: chrome.runtime.MessageSender,
+      sendResponse: (response: ResponseEnvelope) => void,
+    ): boolean | undefined => {
+      // 1. 拡張内発信のみ許可(content script / 他拡張 / Web ページを除外)
+      if (sender.id !== chrome.runtime.id) {
+        return undefined;
+      }
+      // 2. このレイヤーのエンベロープ以外は無視
+      if (!isRequestEnvelope(message)) {
+        return undefined;
+      }
+      // 3. 未知のメッセージ名は拒否
+      if (
+        !Object.prototype.hasOwnProperty.call(contracts, message.__messageName)
+      ) {
+        sendResponse({
+          ok: false,
+          error: `unknown message "${message.__messageName}"`,
+        });
+        return undefined;
+      }
+      const name = message.__messageName as MessageName<M>;
+      const handler = handlers[name];
+      // ハンドラ未登録: 他リスナに委ねるため応答せず無視
+      if (!handler) {
+        return undefined;
+      }
+      // 4. payload の実行時ガード
+      if (!contracts[name].isRequest(message.payload)) {
+        sendResponse({ ok: false, error: `invalid payload for "${name}"` });
+        return undefined;
+      }
+      // 5. ハンドラ実行(同期/非同期の両対応)。例外は握りつぶさずエラー応答にする
+      Promise.resolve(
+        handler(message.payload as RequestOf<M, typeof name>, sender),
+      )
+        .then((data) => sendResponse({ ok: true, data }))
+        .catch((cause: unknown) =>
+          sendResponse({ ok: false, error: toErrorMessage(cause) }),
+        );
+      // 非同期で sendResponse を呼ぶため、チャネルを開いたままにする
+      return true;
+    };
+
+    chrome.runtime.onMessage.addListener(listener);
+    return () => chrome.runtime.onMessage.removeListener(listener);
+  };
+
+  return { sendMessage, addMessageListeners };
+};

--- a/src/lib/messaging/messages.ts
+++ b/src/lib/messaging/messages.ts
@@ -1,0 +1,19 @@
+// アプリのメッセージ契約。新しいメッセージはここに1件追加するだけで、
+// 送信側・受信側の両方で型が保証される。ガードは手書きの型述語で十分
+// (zod 等のランタイム依存は入れない)。
+import { createMessaging, defineMessage } from './createMessaging';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const messages = {
+  // popup → background のサンプル。任意のテキストを送ると挨拶を返す。
+  greet: defineMessage(
+    (value): value is { text: string } =>
+      isRecord(value) && typeof value.text === 'string',
+    (value): value is { reply: string } =>
+      isRecord(value) && typeof value.reply === 'string',
+  ),
+} as const;
+
+export const { sendMessage, addMessageListeners } = createMessaging(messages);

--- a/src/lib/messaging/types.test.ts
+++ b/src/lib/messaging/types.test.ts
@@ -1,0 +1,40 @@
+import { sendMessage } from './messages';
+
+// コンパイル時の型契約テスト。`@ts-expect-error` の各行は「そこで型エラーが
+// 起きること」を要求するため、契約が緩むと `npm run check-type` が落ちる。
+// これらの関数は実行されない(型検査のみ)。
+
+const _requestTypeChecks = () => {
+  // @ts-expect-error 存在しないメッセージ名は拒否される
+  void sendMessage('unknown-message', { text: 'x' });
+
+  // @ts-expect-error payload の型が契約と一致しない(text は string)
+  void sendMessage('greet', { text: 123 });
+
+  // @ts-expect-error payload のプロパティ不足
+  void sendMessage('greet', {});
+
+  // 正しい呼び出しは型エラーにならない
+  void sendMessage('greet', { text: 'ok' });
+};
+
+const _responseTypeChecks = async () => {
+  const res = await sendMessage('greet', { text: 'ok' });
+
+  // response は { reply: string }。存在しないプロパティ参照は型エラー
+  // @ts-expect-error
+  void res.nonExistent;
+
+  // 正しいプロパティ参照は型エラーにならない
+  void res.reply;
+};
+
+// 未使用シンボル警告を避けるため参照する(呼び出しはしない)
+void _requestTypeChecks;
+void _responseTypeChecks;
+
+describe('lib/messaging types', () => {
+  it('コンパイル時の型契約は check-type で検査される', () => {
+    expect(typeof sendMessage).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes #29

## 背景

現状の messaging サンプルは、型なし文字列メッセージ・コールバック API・sender/payload 無検証で、実プロダクト転用時の典型的な脆弱性パターン(`background.ts` が全メッセージに無検証で応答)になっていた。context 間の契約も暗黙で、リファクタリング耐性がなかった。

## 変更内容

依存ゼロの自前薄型 messaging レイヤーを `src/lib/messaging/` に新設し、popup ↔ background のサンプルを置換した。メッセージ定義を1箇所に追加するだけで送受信両側の型が保証され、不正な送信元・不正な payload が既定で拒否される。

- **`createMessaging.ts`** — 契約に非依存な汎用エンジン
  - `defineMessage(isRequest, isResponse)`: request/response の実行時ガードから型を推論する単一ソース
  - `createMessaging(contract)`: 型付き `sendMessage(name, payload)` と `addMessageListeners({...})` を生成
  - `sender.id === chrome.runtime.id` の検証・payload の実行時ガード・未知メッセージを**既定で拒否**。検証失敗は握りつぶさずエラー応答/throw
  - ワイヤ形式は request `{ __messageName, payload }` / response `{ ok, data | error }` エンベロープ
- **`messages.ts`** — アプリのメッセージ契約(利用者が編集する箇所)+ バインド済みインスタンス
- **popup / background** — 既存サンプルを新レイヤーで置換
- **ドキュメント** — `src/lib/README.md` に使い方を追記、旧パターンを指していた `.claude/rules/*.md` を更新

外部依存(zod / @webext-core 等)は追加していない(設計判断 D4)。tabs / Port は意図的に未対応(YAGNI)。

## 受け入れ条件

- [x] 存在しないメッセージ名・payload 型不一致・response 型誤用が**コンパイルエラー**になる(`types.test.ts` の `@ts-expect-error` + `npm run check-type`)
- [x] ユニットテスト: 正常往復 / 不正 payload 拒否 / sender 不一致拒否 が green(`createMessaging.test.ts`、計8ケース)
- [x] `npm run build` が通り、messaging がバンドルされる(実ブラウザでの popup → background 往復は要手動確認)
- [x] `package.json` の dependencies は react / react-dom のまま(新規ランタイム依存なし)

## 検証

- `npm run check-type` ✓
- `npm test` ✓ (12 tests)
- `npm run lint` ✓
- `npm run build` ✓

実ブラウザ確認は `extension/` を unpacked ロード → popup の「send message」ボタンで background から型付き `reply` が表示されることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHixUyj6kNpY4CCr51Bh4C)_