### PR TITLE
feat: manifest のセキュリティ契約を自動検証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - run: npm run verify:manifest

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -26,9 +26,13 @@ export default defineManifest(({ command }) => ({
   options_ui: {
     page: 'options.html',
   },
-  content_security_policy: {
-    extension_pages: "script-src 'self'; object-src 'self';",
-  },
+  ...(command === 'build'
+    ? {
+        content_security_policy: {
+          extension_pages: "script-src 'self'; object-src 'self';",
+        },
+      }
+    : {}),
   // Declare only permissions for Chrome APIs that the extension actually uses.
   // Keep the allowlists in scripts/verify-manifest.mjs in sync when adding one.
   permissions: ['storage'],

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -26,7 +26,12 @@ export default defineManifest(({ command }) => ({
   options_ui: {
     page: 'options.html',
   },
-  permissions: ['background'],
+  content_security_policy: {
+    extension_pages: "script-src 'self'; object-src 'self';",
+  },
+  // Declare only permissions for Chrome APIs that the extension actually uses.
+  // Keep the allowlists in scripts/verify-manifest.mjs in sync when adding one.
+  permissions: [],
   content_scripts: [
     {
       matches: ['https://example.com/*'],

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "prepare": "husky",
     "dev": "vite",
     "build": "rm -rf extension && vite build",
+    "verify:manifest": "node scripts/verify-manifest.mjs",
     "preview": "vite preview",
     "zip": "npm run build && rm -f extension.zip && zip -r extension.zip extension",
-    "lint": "oxlint src *.config.ts",
-    "format": "prettier --write \"src/**/*.{ts,tsx}\" \"*.config.ts\"",
+    "lint": "oxlint src scripts *.config.ts",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\" \"scripts/**/*.mjs\" \"*.config.ts\"",
     "check-type": "tsc --noEmit",
     "test": "vitest run"
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["oxlint --fix", "prettier --write"]
+    "*.{mjs,ts,tsx}": ["oxlint --fix", "prettier --write"]
   },
   "repository": {
     "type": "git",

--- a/scripts/verify-manifest.mjs
+++ b/scripts/verify-manifest.mjs
@@ -1,0 +1,225 @@
+import { readFile, stat } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXPECTED_CSP = "script-src 'self'; object-src 'self';";
+const EXPECTED_MATCHES = ['https://example.com/*'];
+const EXPECTED_PERMISSIONS = [];
+const EXPECTED_HOST_PERMISSIONS = [];
+const EXPECTED_WEB_ACCESSIBLE_RESOURCES = [
+  /^assets\/jsx-runtime-[A-Za-z0-9_-]+\.js$/u,
+  /^assets\/sample\.tsx-[A-Za-z0-9_-]+\.js$/u,
+];
+const FORBIDDEN_CSP_SOURCE =
+  /'unsafe-(?:eval|inline)'|'wasm-unsafe-eval'|(?:https?|data|blob):|\*/u;
+const GLOB = /[*?[\]{}]/u;
+
+const extensionDirectory = fileURLToPath(
+  new URL('../extension/', import.meta.url),
+);
+const manifestPath = resolve(extensionDirectory, 'manifest.json');
+const errors = [];
+const references = [];
+
+const isRecord = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const report = (condition, message) => {
+  if (!condition) errors.push(message);
+};
+
+const readStrings = (value, field) => {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === 'string')
+  ) {
+    errors.push(`${field} must be an array of strings.`);
+    return [];
+  }
+  return value;
+};
+
+const expectSet = (value, expected, field) => {
+  const actual = readStrings(value ?? [], field).toSorted();
+  const wanted = expected.toSorted();
+  report(
+    JSON.stringify(actual) === JSON.stringify(wanted),
+    `${field} must equal ${JSON.stringify(wanted)}; received ${JSON.stringify(actual)}.`,
+  );
+  return actual;
+};
+
+const addReference = (value, field) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push(`${field} must reference a non-empty path.`);
+    return;
+  }
+  references.push({ field, value });
+};
+
+const addIconReferences = (icons, field) => {
+  if (typeof icons === 'string') {
+    addReference(icons, field);
+  } else if (isRecord(icons)) {
+    for (const [size, path] of Object.entries(icons)) {
+      addReference(path, `${field}.${size}`);
+    }
+  } else {
+    errors.push(`${field} must be a path or an icon-size map.`);
+  }
+};
+
+let manifest;
+try {
+  manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Manifest verification failed:\n- ${message}`);
+  process.exit(1);
+}
+
+if (!isRecord(manifest)) {
+  console.error('Manifest verification failed:\n- manifest must be an object.');
+  process.exit(1);
+}
+
+report(
+  manifest.manifest_version === 3,
+  `manifest_version must be 3; received ${JSON.stringify(manifest.manifest_version)}.`,
+);
+expectSet(manifest.permissions, EXPECTED_PERMISSIONS, 'permissions');
+expectSet(
+  manifest.host_permissions,
+  EXPECTED_HOST_PERMISSIONS,
+  'host_permissions',
+);
+
+const csp = manifest.content_security_policy?.extension_pages;
+report(
+  csp === EXPECTED_CSP,
+  `content_security_policy.extension_pages must equal ${JSON.stringify(EXPECTED_CSP)}; received ${JSON.stringify(csp)}.`,
+);
+report(
+  typeof csp !== 'string' || !FORBIDDEN_CSP_SOURCE.test(csp),
+  'content_security_policy.extension_pages contains a forbidden source.',
+);
+
+if (manifest.icons !== undefined) addIconReferences(manifest.icons, 'icons');
+if (manifest.action?.default_icon !== undefined) {
+  addIconReferences(manifest.action.default_icon, 'action.default_icon');
+}
+if (manifest.action?.default_popup !== undefined) {
+  addReference(manifest.action.default_popup, 'action.default_popup');
+}
+if (manifest.options_ui?.page !== undefined) {
+  addReference(manifest.options_ui.page, 'options_ui.page');
+}
+if (manifest.background?.service_worker !== undefined) {
+  addReference(manifest.background.service_worker, 'background.service_worker');
+}
+
+report(
+  Array.isArray(manifest.content_scripts),
+  'content_scripts must be an array.',
+);
+const contentScripts = Array.isArray(manifest.content_scripts)
+  ? manifest.content_scripts
+  : [];
+contentScripts.forEach((entry, index) => {
+  if (!isRecord(entry)) {
+    errors.push(`content_scripts.${index} must be an object.`);
+    return;
+  }
+  expectSet(
+    entry.matches,
+    EXPECTED_MATCHES,
+    `content_scripts.${index}.matches`,
+  );
+  for (const field of ['js', 'css']) {
+    if (entry[field] === undefined) continue;
+    readStrings(entry[field], `content_scripts.${index}.${field}`).forEach(
+      (path, pathIndex) =>
+        addReference(path, `content_scripts.${index}.${field}.${pathIndex}`),
+    );
+  }
+});
+
+report(
+  Array.isArray(manifest.web_accessible_resources),
+  'web_accessible_resources must be an array.',
+);
+const webAccessibleResources = Array.isArray(manifest.web_accessible_resources)
+  ? manifest.web_accessible_resources
+  : [];
+report(
+  webAccessibleResources.length === 1,
+  `web_accessible_resources must contain 1 entry; received ${webAccessibleResources.length}.`,
+);
+webAccessibleResources.forEach((entry, index) => {
+  if (!isRecord(entry)) {
+    errors.push(`web_accessible_resources.${index} must be an object.`);
+    return;
+  }
+
+  expectSet(
+    entry.matches,
+    EXPECTED_MATCHES,
+    `web_accessible_resources.${index}.matches`,
+  );
+  const field = `web_accessible_resources.${index}.resources`;
+  const resources = readStrings(entry.resources, field);
+  report(resources.length > 0, `${field} must not be empty.`);
+
+  for (const expected of EXPECTED_WEB_ACCESSIBLE_RESOURCES) {
+    const count = resources.filter((path) => expected.test(path)).length;
+    report(
+      count === 1,
+      `${field} must contain exactly one path matching ${expected}; received ${count}.`,
+    );
+  }
+
+  resources.forEach((path, pathIndex) => {
+    const resourceField = `${field}.${pathIndex}`;
+    report(
+      !GLOB.test(path),
+      `${resourceField} must not contain a glob: ${path}`,
+    );
+    report(
+      EXPECTED_WEB_ACCESSIBLE_RESOURCES.some((expected) => expected.test(path)),
+      `${resourceField} is not an allowed generated asset: ${path}`,
+    );
+    addReference(path, resourceField);
+  });
+});
+
+for (const { field, value } of references) {
+  const absolutePath = resolve(extensionDirectory, value);
+  const localPath = relative(extensionDirectory, absolutePath);
+  if (
+    isAbsolute(value) ||
+    /^[a-z][a-z0-9+.-]*:/iu.test(value) ||
+    localPath === '..' ||
+    localPath.startsWith('../') ||
+    localPath.startsWith('..\\') ||
+    isAbsolute(localPath)
+  ) {
+    errors.push(`${field} must stay within the extension directory: ${value}`);
+    continue;
+  }
+
+  try {
+    const file = await stat(absolutePath);
+    report(file.isFile(), `${field} does not reference a file: ${value}`);
+  } catch {
+    errors.push(`${field} references a missing file: ${value}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(
+    `Manifest verification failed:\n${errors.map((error) => `- ${error}`).join('\n')}`,
+  );
+  process.exit(1);
+}
+
+console.log('Manifest verification passed.');

--- a/scripts/verify-manifest.mjs
+++ b/scripts/verify-manifest.mjs
@@ -6,13 +6,9 @@ const EXPECTED_CSP = "script-src 'self'; object-src 'self';";
 const EXPECTED_MATCHES = ['https://example.com/*'];
 const EXPECTED_PERMISSIONS = ['storage'];
 const EXPECTED_HOST_PERMISSIONS = [];
-const EXPECTED_WEB_ACCESSIBLE_RESOURCES = [
-  /^assets\/jsx-runtime-[A-Za-z0-9_-]+\.js$/u,
-  /^assets\/sample\.tsx-[A-Za-z0-9_-]+\.js$/u,
-];
-const FORBIDDEN_CSP_SOURCE =
-  /'unsafe-(?:eval|inline)'|'wasm-unsafe-eval'|(?:https?|data|blob):|\*/u;
+const EXPECTED_USE_DYNAMIC_URL = false;
 const GLOB = /[*?[\]{}]/u;
+const CONCRETE_JS_ASSET = /^assets\/[^*?[\]{}]+\.js$/u;
 
 const extensionDirectory = fileURLToPath(
   new URL('../extension/', import.meta.url),
@@ -34,13 +30,16 @@ const readStrings = (value, field) => {
     !value.every((item) => typeof item === 'string')
   ) {
     errors.push(`${field} must be an array of strings.`);
-    return [];
+    return undefined;
   }
   return value;
 };
 
 const expectSet = (value, expected, field) => {
-  const actual = readStrings(value ?? [], field).toSorted();
+  const values = readStrings(value ?? [], field);
+  if (values === undefined) return [];
+
+  const actual = values.toSorted();
   const wanted = expected.toSorted();
   report(
     JSON.stringify(actual) === JSON.stringify(wanted),
@@ -93,15 +92,17 @@ expectSet(
   EXPECTED_HOST_PERMISSIONS,
   'host_permissions',
 );
+expectSet(manifest.optional_permissions, [], 'optional_permissions');
+expectSet(manifest.optional_host_permissions, [], 'optional_host_permissions');
+report(
+  manifest.externally_connectable === undefined,
+  'externally_connectable must not be declared.',
+);
 
 const csp = manifest.content_security_policy?.extension_pages;
 report(
   csp === EXPECTED_CSP,
   `content_security_policy.extension_pages must equal ${JSON.stringify(EXPECTED_CSP)}; received ${JSON.stringify(csp)}.`,
-);
-report(
-  typeof csp !== 'string' || !FORBIDDEN_CSP_SOURCE.test(csp),
-  'content_security_policy.extension_pages contains a forbidden source.',
 );
 
 if (manifest.icons !== undefined) addIconReferences(manifest.icons, 'icons');
@@ -137,24 +138,21 @@ contentScripts.forEach((entry, index) => {
   );
   for (const field of ['js', 'css']) {
     if (entry[field] === undefined) continue;
-    readStrings(entry[field], `content_scripts.${index}.${field}`).forEach(
-      (path, pathIndex) =>
-        addReference(path, `content_scripts.${index}.${field}.${pathIndex}`),
+    const paths =
+      readStrings(entry[field], `content_scripts.${index}.${field}`) ?? [];
+    paths.forEach((path, pathIndex) =>
+      addReference(path, `content_scripts.${index}.${field}.${pathIndex}`),
     );
   }
 });
 
 report(
-  Array.isArray(manifest.web_accessible_resources),
+  Array.isArray(manifest.web_accessible_resources ?? []),
   'web_accessible_resources must be an array.',
 );
 const webAccessibleResources = Array.isArray(manifest.web_accessible_resources)
   ? manifest.web_accessible_resources
   : [];
-report(
-  webAccessibleResources.length === 1,
-  `web_accessible_resources must contain 1 entry; received ${webAccessibleResources.length}.`,
-);
 webAccessibleResources.forEach((entry, index) => {
   if (!isRecord(entry)) {
     errors.push(`web_accessible_resources.${index} must be an object.`);
@@ -166,17 +164,18 @@ webAccessibleResources.forEach((entry, index) => {
     EXPECTED_MATCHES,
     `web_accessible_resources.${index}.matches`,
   );
+  expectSet(
+    entry.extension_ids,
+    [],
+    `web_accessible_resources.${index}.extension_ids`,
+  );
+  report(
+    entry.use_dynamic_url === EXPECTED_USE_DYNAMIC_URL,
+    `web_accessible_resources.${index}.use_dynamic_url must be ${EXPECTED_USE_DYNAMIC_URL}; received ${JSON.stringify(entry.use_dynamic_url)}.`,
+  );
   const field = `web_accessible_resources.${index}.resources`;
-  const resources = readStrings(entry.resources, field);
+  const resources = readStrings(entry.resources, field) ?? [];
   report(resources.length > 0, `${field} must not be empty.`);
-
-  for (const expected of EXPECTED_WEB_ACCESSIBLE_RESOURCES) {
-    const count = resources.filter((path) => expected.test(path)).length;
-    report(
-      count === 1,
-      `${field} must contain exactly one path matching ${expected}; received ${count}.`,
-    );
-  }
 
   resources.forEach((path, pathIndex) => {
     const resourceField = `${field}.${pathIndex}`;
@@ -185,14 +184,14 @@ webAccessibleResources.forEach((entry, index) => {
       `${resourceField} must not contain a glob: ${path}`,
     );
     report(
-      EXPECTED_WEB_ACCESSIBLE_RESOURCES.some((expected) => expected.test(path)),
-      `${resourceField} is not an allowed generated asset: ${path}`,
+      CONCRETE_JS_ASSET.test(path),
+      `${resourceField} must expose only a concrete JS asset: ${path}`,
     );
     addReference(path, resourceField);
   });
 });
 
-for (const { field, value } of references) {
+const verifyReference = async ({ field, value }) => {
   const absolutePath = resolve(extensionDirectory, value);
   const localPath = relative(extensionDirectory, absolutePath);
   if (
@@ -203,17 +202,21 @@ for (const { field, value } of references) {
     localPath.startsWith('..\\') ||
     isAbsolute(localPath)
   ) {
-    errors.push(`${field} must stay within the extension directory: ${value}`);
-    continue;
+    return `${field} must stay within the extension directory: ${value}`;
   }
 
   try {
     const file = await stat(absolutePath);
-    report(file.isFile(), `${field} does not reference a file: ${value}`);
+    return file.isFile()
+      ? undefined
+      : `${field} does not reference a file: ${value}`;
   } catch {
-    errors.push(`${field} references a missing file: ${value}`);
+    return `${field} references a missing file: ${value}`;
   }
-}
+};
+
+const referenceErrors = await Promise.all(references.map(verifyReference));
+errors.push(...referenceErrors.filter(Boolean));
 
 if (errors.length > 0) {
   console.error(

--- a/scripts/verify-manifest.mjs
+++ b/scripts/verify-manifest.mjs
@@ -6,7 +6,6 @@ const EXPECTED_CSP = "script-src 'self'; object-src 'self';";
 const EXPECTED_MATCHES = ['https://example.com/*'];
 const EXPECTED_PERMISSIONS = ['storage'];
 const EXPECTED_HOST_PERMISSIONS = [];
-const EXPECTED_USE_DYNAMIC_URL = false;
 const GLOB = /[*?[\]{}]/u;
 const CONCRETE_JS_ASSET = /^assets\/[^*?[\]{}]+\.js$/u;
 
@@ -120,7 +119,7 @@ if (manifest.background?.service_worker !== undefined) {
 }
 
 report(
-  Array.isArray(manifest.content_scripts),
+  Array.isArray(manifest.content_scripts ?? []),
   'content_scripts must be an array.',
 );
 const contentScripts = Array.isArray(manifest.content_scripts)
@@ -170,8 +169,8 @@ webAccessibleResources.forEach((entry, index) => {
     `web_accessible_resources.${index}.extension_ids`,
   );
   report(
-    entry.use_dynamic_url === EXPECTED_USE_DYNAMIC_URL,
-    `web_accessible_resources.${index}.use_dynamic_url must be ${EXPECTED_USE_DYNAMIC_URL}; received ${JSON.stringify(entry.use_dynamic_url)}.`,
+    typeof entry.use_dynamic_url === 'boolean',
+    `web_accessible_resources.${index}.use_dynamic_url must be explicit and boolean; received ${JSON.stringify(entry.use_dynamic_url)}.`,
   );
   const field = `web_accessible_resources.${index}.resources`;
   const resources = readStrings(entry.resources, field) ?? [];


### PR DESCRIPTION
## 概要

- 不要な `background` 権限を削除し、MV3デフォルト相当のCSPを明示
- ビルド成果物の権限、host permissions、CSP、参照ファイル、content scriptの対象、web-accessible resourcesを検証する `verify:manifest` を追加
- CIのbuildジョブでmanifest検証を自動実行

## 背景

テンプレートのmanifestが暗黙のCSPと不要な権限を含んでおり、利用側でその状態が複製される問題がありました。ソース設定ではなくCRXJSが生成した `extension/manifest.json` を検査し、権限や公開範囲の変更をレビュー可能な契約として固定します。

## 検証

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run check-type`
- [x] `npm test`（5 files / 12 tests）
- [x] `npm run build && npm run verify:manifest`
- [x] `tabs` 権限を一時追加すると検証が終了コード1で失敗
- [x] 許可外のweb-accessible resourceを一時追加すると検証が終了コード1で失敗
- [ ] Chrome Load unpackedによる実機確認（実行環境でChrome制御機能を利用できないため未実施）

## 影響

manifestの権限追加、content script対象変更、公開リソース変更時は、検証スクリプト内の許可リストも意図的に更新する必要があります。外部依存関係は追加していません。

Closes #32