### PR TITLE
feat: Chrome API境界と共通テストfakeを追加

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,6 +11,7 @@ Vitest + jsdom (`vitest.config.ts`: `test: { globals: true, environment: 'jsdom'
   see `useIncrement.test.ts`).
 - Pure functions: plain unit tests (see `calc.test.ts`).
 - Run: `npm test`; watch mode: `npm test -- --watch`.
-- `chrome.*` APIs are not mocked in this setup — code touching them (e.g.
-  `background.ts`, `popup.tsx`) currently has no tests. If you add some,
-  mock `globalThis.chrome` manually.
+- Chrome API を使うテストは `src/lib/testing/chromeFake.ts` の `installChromeFake` を使う。
+  runtime messaging と storage の個別モックを各テストへ重複実装しない。
+- `installChromeFake` は `vi.stubGlobal` で注入するため、`afterEach` で
+  `vi.unstubAllGlobals()` を呼ぶ。

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,7 +11,8 @@ Vitest + jsdom (`vitest.config.ts`: `test: { globals: true, environment: 'jsdom'
   see `useIncrement.test.ts`).
 - Pure functions: plain unit tests (see `calc.test.ts`).
 - Run: `npm test`; watch mode: `npm test -- --watch`.
-- Chrome API を使うテストは `src/lib/testing/chromeFake.ts` の `installChromeFake` を使う。
-  runtime messaging と storage の個別モックを各テストへ重複実装しない。
-- `installChromeFake` は `vi.stubGlobal` で注入するため、`afterEach` で
-  `vi.unstubAllGlobals()` を呼ぶ。
+- Tests that use Chrome APIs must call `installChromeFake` from
+  `src/lib/testing/chromeFake.ts`. Do not duplicate runtime messaging or storage
+  mocks in individual test files.
+- Because `installChromeFake` injects the global with `vi.stubGlobal`, call
+  `vi.unstubAllGlobals()` in `afterEach`.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -38,6 +38,13 @@
             "name": "chrome",
             "message": "Chrome API は src/lib のラッパー経由で利用してください。"
           }
+        ],
+        "no-restricted-properties": [
+          "error",
+          {
+            "property": "chrome",
+            "message": "Chrome API は src/lib のラッパー経由で利用してください。"
+          }
         ]
       }
     }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,8 +27,8 @@
   },
   "overrides": [
     {
-      // Chrome API の実参照は lib の薄い境界層に閉じ込める。型名前空間としての
-      // chrome は no-restricted-globals の対象外なので、@types/chrome は全域で使える。
+      // Keep runtime Chrome API access behind thin src/lib boundaries. Type-only
+      // references through the chrome namespace remain available throughout the project.
       "files": ["src/**/*.{ts,tsx}"],
       "excludeFiles": ["src/lib/**/*.{ts,tsx}"],
       "rules": {
@@ -36,14 +36,14 @@
           "error",
           {
             "name": "chrome",
-            "message": "Chrome API は src/lib のラッパー経由で利用してください。"
+            "message": "Use Chrome APIs through wrappers in src/lib."
           }
         ],
         "no-restricted-properties": [
           "error",
           {
             "property": "chrome",
-            "message": "Chrome API は src/lib のラッパー経由で利用してください。"
+            "message": "Use Chrome APIs through wrappers in src/lib."
           }
         ]
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,6 +25,23 @@
     // must be enabled explicitly to preserve the old severity/intent.
     "typescript/no-non-null-assertion": "warn"
   },
+  "overrides": [
+    {
+      // Chrome API の実参照は lib の薄い境界層に閉じ込める。型名前空間としての
+      // chrome は no-restricted-globals の対象外なので、@types/chrome は全域で使える。
+      "files": ["src/**/*.{ts,tsx}"],
+      "excludeFiles": ["src/lib/**/*.{ts,tsx}"],
+      "rules": {
+        "no-restricted-globals": [
+          "error",
+          {
+            "name": "chrome",
+            "message": "Chrome API は src/lib のラッパー経由で利用してください。"
+          }
+        ]
+      }
+    }
+  ],
   "env": {
     "builtin": true,
     "browser": true

--- a/README.md
+++ b/README.md
@@ -76,13 +76,17 @@ type check、lint、test、build のチェックを、main への push と pull 
 ## ディレクトリ構成
 
 - `src/entrypoints/{popup,options,background,content}/` : 拡張機能の各サーフェス(エントリポイント)
-- `src/lib/` : entrypoints から利用する共有モジュール置き場(messaging / storage は後続 Issue で追加予定)
+- `src/lib/` : entrypoints から利用する共有モジュール置き場(messaging / storage、Chrome API 境界、共通テストfake)
 - `src/examples/` : 学習用のサンプル実装(components / hooks / utils)。不要であれば `src/examples/` ごと削除可能
 
 依存方向の規約:
 
 - `entrypoints → lib` は許可、`lib → entrypoints` は禁止
-- entrypoints 同士の直接 import は禁止(サーフェス間の通信は今後実装する messaging 経由)
+- entrypoints 同士の直接 import は禁止(サーフェス間の通信は messaging 経由)
+- `chrome` グローバルの実参照は `src/lib/` 内のみ許可。entrypoints から Chrome API を使う場合は lib に薄いラッパーを追加する
+
+この Chrome API 境界は Oxlint で静的に検査される。例外が不可避な場合だけ、理由を
+明記した `oxlint-disable` コメントを使用する。`@types/chrome` の型参照は全域で利用できる。
 
 DevTools パネルは本 template では提供していません。追加したい場合は
 [chrome.devtools 公式ドキュメント](https://developer.chrome.com/docs/extensions/reference/api/devtools)を参照してください。

--- a/src/entrypoints/options/options.tsx
+++ b/src/entrypoints/options/options.tsx
@@ -42,7 +42,7 @@ const Root = () => {
       }}
     >
       <h1>Options</h1>
-      <p>保存した値は chrome.storage.sync に保持され、popup からも読めます。</p>
+      <p>保存した値は同期ストレージに保持され、popup からも読めます。</p>
       <form onSubmit={onSubmit}>
         <label htmlFor="example-setting">共有設定</label>
         <input

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -3,7 +3,12 @@
 entrypoints から利用する共有モジュールの置き場です。
 
 - 依存方向は `entrypoints → lib` のみ許可。`lib` から `entrypoints` への import は禁止
-- storage は後続 Issue で実装予定
+- Chrome API の実参照は `src/lib/` 内だけで許可。entrypoints などからは lib のラッパーを利用する
+- 例外が不可避な場合は `oxlint-disable` コメントに理由を記載し、境界違反を顕在化する
+
+テストでは `src/lib/testing/chromeFake.ts` の `installChromeFake` を使う。runtime
+messaging と storage(local / managed / session / sync)を in-memory で再現し、
+`vi.stubGlobal` でテストごとに注入できる。
 
 ## messaging(`src/lib/messaging/`)
 

--- a/src/lib/messaging/createMessaging.test.ts
+++ b/src/lib/messaging/createMessaging.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installChromeFake, type ChromeFake } from '../testing/chromeFake';
 import { createMessaging, defineMessage } from './createMessaging';
 
 const EXTENSION_ID = 'test-extension-id';
@@ -15,46 +17,15 @@ const testMessages = {
   ),
 } as const;
 
-type Listener = (
-  message: unknown,
-  sender: chrome.runtime.MessageSender,
-  sendResponse: (response: unknown) => void,
-) => boolean | undefined;
-
-let listeners: Listener[] = [];
-// 次に送るメッセージの sender。既定は拡張自身(検証を通る)。
-let nextSender: chrome.runtime.MessageSender = { id: EXTENSION_ID };
-
-const setupChromeMock = () => {
-  listeners = [];
-  nextSender = { id: EXTENSION_ID };
-  const chromeMock = {
-    runtime: {
-      id: EXTENSION_ID,
-      onMessage: {
-        addListener: (fn: Listener) => listeners.push(fn),
-        removeListener: (fn: Listener) => {
-          listeners = listeners.filter((registered) => registered !== fn);
-        },
-      },
-      // 登録済みリスナへ配送し、最初に sendResponse された値で resolve する。
-      sendMessage: (message: unknown) =>
-        new Promise<unknown>((resolve) => {
-          for (const listener of listeners) {
-            const keepChannelOpen = listener(message, nextSender, resolve);
-            if (keepChannelOpen) return;
-          }
-          resolve(undefined);
-        }),
-    },
-  };
-  globalThis.chrome = chromeMock as unknown as typeof chrome;
-};
+let chromeFake: ChromeFake;
 
 describe('lib/messaging/createMessaging', () => {
-  beforeEach(setupChromeMock);
+  beforeEach(() => {
+    chromeFake = installChromeFake({ extensionId: EXTENSION_ID });
+  });
   afterEach(() => {
-    listeners = [];
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('型付き payload を送り、型付き response を受け取れる(正常往復)', async () => {
@@ -85,7 +56,7 @@ describe('lib/messaging/createMessaging', () => {
     addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
 
     // 型を迂回してガードに合致しない payload を直接送る
-    const response = await chrome.runtime.sendMessage({
+    const response = await chromeFake.chrome.runtime.sendMessage({
       __messageName: 'greet',
       payload: { text: 123 },
     });
@@ -100,7 +71,7 @@ describe('lib/messaging/createMessaging', () => {
     const { sendMessage, addMessageListeners } = createMessaging(testMessages);
     addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
 
-    nextSender = { id: 'malicious-extension-id' };
+    chromeFake.setRuntimeSender({ id: 'malicious-extension-id' });
 
     await expect(sendMessage('greet', { text: 'world' })).rejects.toThrow(
       /no valid response/,
@@ -111,7 +82,7 @@ describe('lib/messaging/createMessaging', () => {
     const { addMessageListeners } = createMessaging(testMessages);
     addMessageListeners({ greet: (payload) => ({ reply: payload.text }) });
 
-    const response = await chrome.runtime.sendMessage({
+    const response = await chromeFake.chrome.runtime.sendMessage({
       __messageName: 'unknown-message',
       payload: {},
     });

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installChromeFake, type ChromeFake } from '../testing/chromeFake';
 import {
   getStorageValue,
   onStorageValueChanged,
@@ -6,74 +7,14 @@ import {
   setStorageValue,
 } from './storage';
 
-type StorageListener = Parameters<
-  typeof chrome.storage.onChanged.addListener
->[0];
-
-const createStorageArea = () => {
-  const store = new Map<string, unknown>();
-
-  return {
-    get: vi.fn(
-      async (keys?: string | string[] | Record<string, unknown> | null) => {
-        if (typeof keys === 'string') {
-          return { [keys]: store.get(keys) };
-        }
-
-        if (Array.isArray(keys)) {
-          return Object.fromEntries(keys.map((key) => [key, store.get(key)]));
-        }
-
-        if (keys && typeof keys === 'object') {
-          return Object.fromEntries(
-            Object.entries(keys).map(([key, defaultValue]) => [
-              key,
-              store.has(key) ? store.get(key) : defaultValue,
-            ]),
-          );
-        }
-
-        return Object.fromEntries(store);
-      },
-    ),
-    remove: vi.fn(async (keys: string | string[]) => {
-      for (const key of Array.isArray(keys) ? keys : [keys]) {
-        store.delete(key);
-      }
-    }),
-    set: vi.fn(async (items: Record<string, unknown>) => {
-      for (const [key, value] of Object.entries(items)) {
-        store.set(key, value);
-      }
-    }),
-  };
-};
-
-const listeners = new Set<StorageListener>();
+let chromeFake: ChromeFake;
 
 beforeEach(() => {
-  const sync = createStorageArea();
-
-  globalThis.chrome = {
-    storage: {
-      sync,
-      local: createStorageArea(),
-      managed: createStorageArea(),
-      session: createStorageArea(),
-      onChanged: {
-        addListener: vi.fn((listener: StorageListener) => {
-          listeners.add(listener);
-        }),
-        removeListener: vi.fn((listener: StorageListener) => {
-          listeners.delete(listener);
-        }),
-      },
-    },
-  } as unknown as typeof chrome;
+  chromeFake = installChromeFake();
 });
 
 afterEach(() => {
-  listeners.clear();
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -95,25 +36,19 @@ describe('typed storage', () => {
     await expect(getStorageValue('exampleSetting')).resolves.toBe('未設定');
   });
 
-  it('subscribes to typed storage changes for a key', () => {
+  it('subscribes to typed storage changes for a key', async () => {
     const listener = vi.fn();
     const unsubscribe = onStorageValueChanged('exampleSetting', listener);
 
-    for (const storageListener of listeners) {
-      storageListener(
-        {
-          exampleSetting: {
-            oldValue: '変更前',
-            newValue: '変更後',
-          },
-        },
-        'sync',
-      );
-    }
+    await setStorageValue('exampleSetting', '変更前');
+    listener.mockClear();
+    await setStorageValue('exampleSetting', '変更後');
 
     expect(listener).toHaveBeenCalledWith('変更後', '変更前');
 
     unsubscribe();
-    expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledTimes(1);
+    expect(
+      chromeFake.chrome.storage.onChanged.removeListener,
+    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/testing/chromeFake.test.ts
+++ b/src/lib/testing/chromeFake.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createChromeFake } from './chromeFake';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Chrome fake', () => {
+  it('omits missing keys from string and array storage reads', async () => {
+    const fake = createChromeFake();
+    await fake.chrome.storage.local.set({ present: 'value' });
+
+    await expect(fake.chrome.storage.local.get('missing')).resolves.toEqual({});
+    await expect(
+      fake.chrome.storage.local.get(['present', 'missing']),
+    ).resolves.toEqual({ present: 'value' });
+  });
+
+  it('dispatches a runtime message to every registered listener', async () => {
+    const fake = createChromeFake();
+    const asyncListener = vi.fn((_message, _sender, sendResponse) => {
+      queueMicrotask(() => sendResponse('async response'));
+      return true;
+    });
+    const syncListener = vi.fn((_message, _sender, sendResponse) => {
+      sendResponse('sync response');
+    });
+    fake.chrome.runtime.onMessage.addListener(asyncListener);
+    fake.chrome.runtime.onMessage.addListener(syncListener);
+
+    await expect(fake.chrome.runtime.sendMessage({})).resolves.toBe(
+      'sync response',
+    );
+    expect(asyncListener).toHaveBeenCalledOnce();
+    expect(syncListener).toHaveBeenCalledOnce();
+  });
+
+  it('does not emit a storage change when a value remains unchanged', async () => {
+    const fake = createChromeFake();
+    const listener = vi.fn();
+    fake.chrome.storage.onChanged.addListener(listener);
+    await fake.chrome.storage.sync.set({ setting: 'same' });
+    listener.mockClear();
+
+    await fake.chrome.storage.sync.set({ setting: 'same' });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('implements the additional StorageArea methods', async () => {
+    const fake = createChromeFake();
+    const areas = [
+      fake.chrome.storage.local,
+      fake.chrome.storage.managed,
+      fake.chrome.storage.session,
+      fake.chrome.storage.sync,
+    ];
+
+    for (const area of areas) {
+      expect(area.clear).toBeTypeOf('function');
+      expect(area.getBytesInUse).toBeTypeOf('function');
+      expect(area.getKeys).toBeTypeOf('function');
+      expect(area.setAccessLevel).toBeTypeOf('function');
+    }
+
+    await fake.chrome.storage.local.set({ first: 'value', second: 2 });
+    await expect(fake.chrome.storage.local.getKeys()).resolves.toEqual([
+      'first',
+      'second',
+    ]);
+    await expect(
+      fake.chrome.storage.local.getBytesInUse('first'),
+    ).resolves.toBeGreaterThan(0);
+    await expect(
+      fake.chrome.storage.local.getBytesInUse('missing'),
+    ).resolves.toBe(0);
+    await expect(
+      fake.chrome.storage.local.setAccessLevel({
+        accessLevel: 'TRUSTED_CONTEXTS',
+      }),
+    ).resolves.toBeUndefined();
+
+    await fake.chrome.storage.local.clear();
+    await expect(fake.chrome.storage.local.get()).resolves.toEqual({});
+  });
+});

--- a/src/lib/testing/chromeFake.ts
+++ b/src/lib/testing/chromeFake.ts
@@ -45,11 +45,13 @@ const getStoredValues = (
   keys?: string | string[] | Record<string, unknown> | null,
 ): Record<string, unknown> => {
   if (typeof keys === 'string') {
-    return { [keys]: store.get(keys) };
+    return store.has(keys) ? { [keys]: store.get(keys) } : {};
   }
 
   if (Array.isArray(keys)) {
-    return Object.fromEntries(keys.map((key) => [key, store.get(key)]));
+    return Object.fromEntries(
+      keys.filter((key) => store.has(key)).map((key) => [key, store.get(key)]),
+    );
   }
 
   if (keys) {
@@ -64,6 +66,28 @@ const getStoredValues = (
   return Object.fromEntries(store);
 };
 
+const getBytesInUse = (
+  store: Map<string, unknown>,
+  keys?: string | string[] | null,
+): number => {
+  const selectedKeys =
+    keys == null ? [...store.keys()] : typeof keys === 'string' ? [keys] : keys;
+  const encoder = new TextEncoder();
+
+  return selectedKeys.reduce((total, key) => {
+    if (!store.has(key)) {
+      return total;
+    }
+
+    const serializedValue = JSON.stringify(store.get(key)) ?? '';
+    return (
+      total +
+      encoder.encode(key).byteLength +
+      encoder.encode(serializedValue).byteLength
+    );
+  }, 0);
+};
+
 const createStorageArea = (
   areaName: chrome.storage.AreaName,
   emitChanges: (
@@ -74,7 +98,21 @@ const createStorageArea = (
   const store = new Map<string, unknown>();
 
   return {
+    clear: vi.fn(async () => {
+      const changes = Object.fromEntries(
+        [...store].map(([key, oldValue]) => [key, { oldValue }]),
+      );
+
+      if (store.size === 0) {
+        return;
+      }
+
+      store.clear();
+      emitChanges(changes, areaName);
+    }),
     get: vi.fn(async (keys) => getStoredValues(store, keys)),
+    getBytesInUse: vi.fn(async (keys) => getBytesInUse(store, keys)),
+    getKeys: vi.fn(async () => [...store.keys()]),
     remove: vi.fn(async (keys: string | string[]) => {
       const changes: Record<string, chrome.storage.StorageChange> = {};
 
@@ -108,6 +146,7 @@ const createStorageArea = (
         emitChanges(changes, areaName);
       }
     }),
+    setAccessLevel: vi.fn(async (_accessOptions) => undefined),
   } as unknown as chrome.storage.StorageArea;
 };
 
@@ -142,24 +181,32 @@ export const createChromeFake = (
       sendMessage: vi.fn(
         (message: unknown) =>
           new Promise<unknown>((resolve) => {
+            let channelKeptOpen = false;
+            let responded = false;
+            const sendResponse = (response: unknown) => {
+              if (responded) {
+                return;
+              }
+
+              responded = true;
+              resolve(response);
+            };
+
             for (const listener of runtimeListeners) {
-              let responded = false;
-              const sendResponse = (response: unknown) => {
-                responded = true;
-                resolve(response);
-              };
               const keepChannelOpen = listener(
                 message,
                 runtimeSender,
                 sendResponse,
               );
 
-              if (responded || keepChannelOpen === true) {
-                return;
+              if (keepChannelOpen === true) {
+                channelKeptOpen = true;
               }
             }
 
-            resolve(undefined);
+            if (!responded && !channelKeptOpen) {
+              resolve(undefined);
+            }
           }),
       ),
     },

--- a/src/lib/testing/chromeFake.ts
+++ b/src/lib/testing/chromeFake.ts
@@ -1,0 +1,196 @@
+import { vi } from 'vitest';
+
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void,
+) => boolean | undefined | void;
+type StorageChangeListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: chrome.storage.AreaName,
+) => void;
+
+type ChromeFakeOptions = {
+  extensionId?: string;
+};
+
+export type ChromeFake = {
+  chrome: ChromeApiFake;
+  setRuntimeSender: (sender: chrome.runtime.MessageSender) => void;
+};
+
+type ChromeApiFake = {
+  runtime: {
+    id: string;
+    onMessage: {
+      addListener: (listener: RuntimeMessageListener) => void;
+      removeListener: (listener: RuntimeMessageListener) => void;
+    };
+    sendMessage: (message: unknown) => Promise<unknown>;
+  };
+  storage: {
+    local: chrome.storage.StorageArea;
+    managed: chrome.storage.StorageArea;
+    session: chrome.storage.StorageArea;
+    sync: chrome.storage.StorageArea;
+    onChanged: {
+      addListener: (listener: StorageChangeListener) => void;
+      removeListener: (listener: StorageChangeListener) => void;
+    };
+  };
+};
+
+const getStoredValues = (
+  store: Map<string, unknown>,
+  keys?: string | string[] | Record<string, unknown> | null,
+): Record<string, unknown> => {
+  if (typeof keys === 'string') {
+    return { [keys]: store.get(keys) };
+  }
+
+  if (Array.isArray(keys)) {
+    return Object.fromEntries(keys.map((key) => [key, store.get(key)]));
+  }
+
+  if (keys) {
+    return Object.fromEntries(
+      Object.entries(keys).map(([key, defaultValue]) => [
+        key,
+        store.has(key) ? store.get(key) : defaultValue,
+      ]),
+    );
+  }
+
+  return Object.fromEntries(store);
+};
+
+const createStorageArea = (
+  areaName: chrome.storage.AreaName,
+  emitChanges: (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: chrome.storage.AreaName,
+  ) => void,
+): chrome.storage.StorageArea => {
+  const store = new Map<string, unknown>();
+
+  return {
+    get: vi.fn(async (keys) => getStoredValues(store, keys)),
+    remove: vi.fn(async (keys: string | string[]) => {
+      const changes: Record<string, chrome.storage.StorageChange> = {};
+
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (!store.has(key)) {
+          continue;
+        }
+
+        changes[key] = { oldValue: store.get(key) };
+        store.delete(key);
+      }
+
+      if (Object.keys(changes).length > 0) {
+        emitChanges(changes, areaName);
+      }
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      const changes: Record<string, chrome.storage.StorageChange> = {};
+
+      for (const [key, value] of Object.entries(items)) {
+        const oldValue = store.get(key);
+        if (store.has(key) && Object.is(oldValue, value)) {
+          continue;
+        }
+
+        store.set(key, value);
+        changes[key] = { oldValue, newValue: value };
+      }
+
+      if (Object.keys(changes).length > 0) {
+        emitChanges(changes, areaName);
+      }
+    }),
+  } as unknown as chrome.storage.StorageArea;
+};
+
+export const createChromeFake = (
+  options: ChromeFakeOptions = {},
+): ChromeFake => {
+  const extensionId = options.extensionId ?? 'test-extension-id';
+  const runtimeListeners = new Set<RuntimeMessageListener>();
+  const storageListeners = new Set<StorageChangeListener>();
+  let runtimeSender: chrome.runtime.MessageSender = { id: extensionId };
+
+  const emitStorageChanges = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    areaName: chrome.storage.AreaName,
+  ) => {
+    for (const listener of storageListeners) {
+      listener(changes, areaName);
+    }
+  };
+
+  const chromeFake: ChromeApiFake = {
+    runtime: {
+      id: extensionId,
+      onMessage: {
+        addListener: vi.fn((listener: RuntimeMessageListener) => {
+          runtimeListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: RuntimeMessageListener) => {
+          runtimeListeners.delete(listener);
+        }),
+      },
+      sendMessage: vi.fn(
+        (message: unknown) =>
+          new Promise<unknown>((resolve) => {
+            for (const listener of runtimeListeners) {
+              let responded = false;
+              const sendResponse = (response: unknown) => {
+                responded = true;
+                resolve(response);
+              };
+              const keepChannelOpen = listener(
+                message,
+                runtimeSender,
+                sendResponse,
+              );
+
+              if (responded || keepChannelOpen === true) {
+                return;
+              }
+            }
+
+            resolve(undefined);
+          }),
+      ),
+    },
+    storage: {
+      local: createStorageArea('local', emitStorageChanges),
+      managed: createStorageArea('managed', emitStorageChanges),
+      session: createStorageArea('session', emitStorageChanges),
+      sync: createStorageArea('sync', emitStorageChanges),
+      onChanged: {
+        addListener: vi.fn((listener: StorageChangeListener) => {
+          storageListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: StorageChangeListener) => {
+          storageListeners.delete(listener);
+        }),
+      },
+    },
+  };
+
+  return {
+    chrome: chromeFake,
+    setRuntimeSender: (sender) => {
+      runtimeSender = sender;
+    },
+  };
+};
+
+export const installChromeFake = (
+  options: ChromeFakeOptions = {},
+): ChromeFake => {
+  const fake = createChromeFake(options);
+  vi.stubGlobal('chrome', fake.chrome);
+  return fake;
+};


### PR DESCRIPTION
## 概要

`chrome` グローバルへの実参照を `src/lib/**` に限定し、runtime messaging / storage の共通in-memory fakeを追加します。

Closes #31

## 変更内容

- Oxlintの `no-restricted-globals` / `no-restricted-properties` とディレクトリoverrideで、`src/lib/**` 外の `chrome` 実参照をエラー化
- runtime messagingとstorage（local / managed / session / sync）を再現する `installChromeFake` を追加
- messaging / storageテストの個別モックを共通fakeへ集約
- entrypoints外からChrome APIを使う依存規約と例外運用をREADME・テスト規約へ追記
- grep検査に残るUI文言の `chrome.storage.sync` 表記を「同期ストレージ」へ変更

## レビュー対応

- `globalThis.chrome` / `window.chrome` / `self.chrome` / cast後の `.chrome` / bracket accessもlintで拒否
- storageのstring / array取得時、欠損キーを結果から省略
- runtime messageを全登録listenerへ配送し、最初のresponseだけを採用
- `clear` / `getBytesInUse` / `getKeys` / `setAccessLevel` をfakeへ追加
- 同値setはChrome公式仕様の「値が変更された場合にonChanged発火」に合わせて通知を抑制し、回帰テストを追加

## 背景・影響

Chrome API依存の局所化がレビュー上の規約だけだったため、entrypointsから直接APIを呼んでも検知できませんでした。今回の変更により、境界違反はlint時点で失敗し、テストでは同じfakeを再利用できます。型としての `@types/chrome` は引き続き全域で利用できます。

## 検証

- `npm run lint`
- `npm run check-type`
- `npm test`（7 files / 20 tests passed）
- `npm run build`
- 一時検証ファイルで裸の `chrome` と5種類のプロパティ経由参照がすべてlint失敗することを確認
- 同じ検証コードが `src/lib` ではlint成功することを確認
- `src/lib` 外の `chrome.` 参照が0件であることを確認