### PR TITLE
feat: add dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    # メジャーバージョン更新はグルーピング対象外で個別PRとして作成される。
+    # 破壊的変更を含む可能性があるため、CHANGELOG確認のうえ手動で判断すること。
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+    # メジャーバージョン更新は個別PRになる。破壊的変更の可能性があるため手動で判断すること。


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を新設し、npm / github-actions 両エコシステムの更新PRを weekly で自動提案するようにした
- パッチ・マイナー更新はグルーピングしてPRノイズを抑制。メジャー更新はグルーピング対象外とし、個別PRとして作成させる
- メジャー更新は破壊的変更を含む可能性があるため、CHANGELOG確認のうえ手動判断する旨をファイル内コメントに明記
- 自動マージ・npm audit の CI 強制は対象外(スコープ外・リスク側に倒れるため導入しない)

## Test plan

- [x] `.github/dependabot.yml` の YAML構文を Python(`yaml.safe_load`)でパースし妥当性を確認
- [ ] マージ後、GitHub の Insights > Dependency graph > Dependabot でエラーなく認識されることを確認
- [ ] npm / github-actions 両エコシステムの更新PRが作成されることを確認(次回スケジュール実行、または手動の「Check for updates」)
- [ ] 作成された更新PR上で既存CI(`.github/workflows/ci.yml`)が実行されることを確認

Closes #35

Claude-Session: https://claude.ai/code/session_012nSzfwgvuSRdUJmxuSb4TZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012nSzfwgvuSRdUJmxuSb4TZ)_