### PR TITLE
docs: add OSS contributor files (CONTRIBUTING, SECURITY, CoC, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a problem with the extension or template
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out the sections below so it can be reproduced quickly.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Extension version / commit SHA
+      description: The `package.json` version or commit SHA you're on.
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: "Chrome 126.0.6478.126"
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      placeholder: "24.x"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, console errors, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea or enhancement for this template
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and this hasn't been requested yet.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Related issue
+
+<!-- Closes #___ -->
+
+## Verification
+
+<!-- Check the commands you ran locally -->
+
+- [ ] `npm run check-type`
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run build`
+- [ ] `npm run e2e` (if applicable)
+
+## Breaking changes
+
+- [ ] This PR introduces breaking changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+A dedicated private contact channel is not yet published; tracked in
+[#58](https://github.com/50ra4/crx-vite-ts-react-template/issues/58). Until it
+is set up, please report instances of abusive, harassing, or otherwise
+unacceptable behavior by opening a GitHub issue addressed to the maintainer
+([@50ra4](https://github.com/50ra4)). All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of
+Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,12 +51,16 @@ when an individual is officially representing the community in public spaces.
 
 ## Enforcement
 
-A dedicated private contact channel is not yet published; tracked in
+A dedicated private contact channel for Code of Conduct reports is not yet
+published; tracked in
 [#58](https://github.com/50ra4/crx-vite-ts-react-template/issues/58). Until it
 is set up, please report instances of abusive, harassing, or otherwise
-unacceptable behavior by opening a GitHub issue addressed to the maintainer
-([@50ra4](https://github.com/50ra4)). All complaints will be reviewed and
-investigated promptly and fairly.
+unacceptable behavior privately through GitHub's [Private Vulnerability
+Reporting](./SECURITY.md) (repository's **Security** tab → **Report a
+vulnerability**) rather than a public issue — this keeps the report
+confidential between you and the maintainer even though the feature is
+named for security issues. All complaints will be reviewed and investigated
+promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Thanks for your interest in contributing to this project. This document covers
+setup, verification commands, and the branch/PR flow. For architecture,
+directory layout, and dependency-direction rules, see the README's
+"ディレクトリ構成" section. For AI-agent-specific conventions, see
+`AGENTS.md` and `.claude/rules/`.
+
+## Getting started
+
+Requires Node.js `>=24.0.0` (see `.nvmrc`).
+
+```sh
+npm ci
+npm run dev
+```
+
+`npm ci` also installs the `husky` pre-commit hook (via the `prepare` script),
+which runs `oxlint --fix` and `prettier --write` on staged files automatically.
+
+## Before you push
+
+Run the same checks CI runs, in the same order:
+
+```sh
+npm run check-type
+npm run lint
+npm run test
+npm run build && npm run verify:manifest
+```
+
+- `npm run lint` is check-only; use `npm run format` to auto-fix formatting.
+- Code style (formatting, quote style, etc.) is enforced by Oxlint/Prettier —
+  run them, don't hand-format.
+- E2E tests (`npm run e2e`) require a prior build and Chromium installed once
+  via `npx playwright install chromium`. Run `npm run build && npm run e2e`
+  before submitting changes that affect runtime behavior.
+
+## Branching and commits
+
+- Branch from `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) types:
+  `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`.
+- Commit messages should explain *why*, not just *what*.
+
+## Pull requests
+
+- Open PRs against `main`. The PR template is applied automatically — fill in
+  the summary, verification steps, and breaking-change checkbox.
+- All CI jobs (type-check, lint, test, build, e2e) must pass before merge.
+- By submitting a PR, you agree your contribution is licensed under this
+  project's [MIT License](./LICENSE).
+
+## Reporting bugs and requesting features
+
+Use the issue templates (bug report / feature request) when opening a new
+issue. Do **not** file a public issue for security vulnerabilities — see
+[SECURITY.md](./SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+This project does not maintain versioned releases; only the latest commit on
+`main` is supported. Please update to the latest `main` before reporting a
+vulnerability.
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub
+issues.
+
+Instead, use GitHub's [Private Vulnerability
+Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
+go to the repository's **Security** tab and select **Report a vulnerability**.
+
+This is a personally maintained project; responses are best-effort and there
+is no guaranteed SLA.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` — setup, verification commands (mirrors CI order: `check-type` → `lint` → `test` → `build`+`verify:manifest` → `e2e`), branch/commit/PR flow. Delegates coding style to Oxlint/Prettier and points to README/AGENTS.md for architecture instead of duplicating.
- Add `SECURITY.md` — vulnerability reports via GitHub Private Vulnerability Reporting only (no public issues, no email fallback).
- Add `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1. The enforcement contact is a placeholder pointing to a new tracking issue (#58) since no dedicated contact email is set up yet.
- Add `.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml` (YAML forms with structured fields for repro steps / version / browser), and `config.yml` (`blank_issues_enabled: false`).
- Add `.github/PULL_REQUEST_TEMPLATE.md` — summary, related issue, verification checklist matching CI, breaking-change checkbox.

Closes #37

## Verification

- [x] Validated all new YAML files parse correctly (`python3 -c "import yaml; ..."`)
- [x] `git status` confirms only the intended 7 files were added
- These files aren't in the lint/format target globs (`src scripts e2e *.config.ts`), so `npm run lint`/`npm run format` don't apply here.

## Owner action required (cannot be done via PR)

- [ ] Enable **Private Vulnerability Reporting** in repo Settings → Security, so the flow described in `SECURITY.md` actually works.
- [ ] Follow up on #58 to set a real enforcement contact in `CODE_OF_CONDUCT.md`.

## Breaking changes

- [ ] This PR introduces breaking changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01NTchyPZM6osgyUBeuBHBYp)_