### PR TITLE
[ISSUE 38] docs: AI エージェント向け設計契約・検証契約(AGENTS.md + verify)を整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,9 @@ not this file — is the authority; the note explains the intent a check cannot.
 
 ## Recipes
 
-Minimal, real code paths for the common changes. Finish each with `npm run verify`.
+Minimal, real code paths for the common changes. Each recipe ends with the
+verification its change type calls for in **Verification contract** above — not a
+blanket command.
 
 - **Add a message type.** In `src/lib/messaging/messages.ts`, add one entry to
   `messages` via `defineMessage(isRequest, isResponse)` (hand-written type-guard
@@ -81,15 +83,19 @@ Minimal, real code paths for the common changes. Finish each with `npm run verif
   `src/entrypoints/background/background.ts` under `addMessageListeners({ ... })`, and
   send from a surface with `sendMessage(name, payload)`. The generic engine in
   `createMessaging.ts` needs no change; sender check and payload guards are automatic.
+  This touches entrypoint wiring (`background.ts` + a surface), so verify with
+  **`npm run verify:full`** — only the real-Chromium e2e exercises the messaging round-trip.
 - **Add a storage key.** In `src/lib/storage/schema.ts`, add the key to the
   `AppStorageValues` type and to `storageSchema` (`area` + `defaultValue`). Everything
   else (`getStorageValue` / `setStorageValue` / `removeStorageValue` /
   `onStorageValueChanged` / `useStorageValue`) is generic and follows automatically.
+  The schema edit is `src/lib/**`-only, so **`npm run verify`** covers it; if you also
+  wire a surface to read or write the key, verify that with `npm run verify:full`.
 - **Add a Chrome permission.** Add it to `permissions` (or `host_permissions` /
   `optional_permissions`) in `manifest.config.ts`, **and** update the matching
   allowlist (`EXPECTED_PERMISSIONS`, `EXPECTED_HOST_PERMISSIONS`, …) in
   `scripts/verify-manifest.mjs`. A mismatch makes `verify:manifest` fail by design —
-  that failure is the guard against silent privilege growth.
+  that failure is the guard against silent privilege growth. **`npm run verify`** asserts it.
 
 ## Forbidden changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ README's "ディレクトリ構成" section for the full dependency-direction ru
 | `npm run dev` | Vite dev server with HMR | via `@crxjs/vite-plugin` |
 | `npm run build` | Build to `extension/` | deletes and recreates the dir |
 | `npm run package` | Build, verify manifest, create reproducible `extension.zip` | archives distributable files from `extension/` |
+| `npm run verify` | check-type → lint → test → build → verify:manifest, in series | the safety contract for most changes; excludes e2e for speed |
+| `npm run verify:full` | `verify` then `npm run e2e` | full contract; requires installed Chromium |
 | `npm run e2e` | Run Playwright Chromium smoke tests | requires a prior build and installed Chromium |
 | `npm run check-type` | `tsc --noEmit` | |
 | `npm test` | Run Vitest | src tests use jsdom; script tests use Node |
@@ -25,6 +27,82 @@ README's "ディレクトリ構成" section for the full dependency-direction ru
 | `npm run zip` | Alias for `npm run package` | |
 
 `.nvmrc` pins Node 24, matching the `engines.node` (`>=24.0.0`) requirement.
+
+## Verification contract
+
+After changing code, prove it is safe with a single command. **The source of truth
+is the checks themselves** (types, lint, tests, `verify:manifest`) — this section
+only tells you which to run.
+
+- `npm run verify` — check-type → lint → test → build → verify:manifest, in series.
+  This is the contract for most changes. `verify:manifest` reads the built
+  `extension/manifest.json`, so `build` always runs before it. e2e is excluded here
+  because it needs a real Chromium and is slow.
+- `npm run verify:full` — `verify` then `npm run e2e` (real Chromium smoke tests).
+  Run this when your change could affect the built extension's runtime wiring.
+
+Minimum verification per change type:
+
+| Change | Run |
+| --- | --- |
+| `src/lib/**`, types, unit tests, `src/examples/**` | `npm run verify` |
+| `manifest.config.ts`, permissions, CSP | `npm run verify` (asserts the manifest) |
+| entrypoint wiring, messaging/storage round-trips, anything e2e exercises | `npm run verify:full` |
+
+CI is not changed by this file: it already runs the same underlying checks as
+separate jobs. `verify` / `verify:full` are the local and agent-facing entry points.
+
+## Architecture invariants
+
+These hold regardless of the task. Where a check enforces an invariant, that check —
+not this file — is the authority; the note explains the intent a check cannot.
+
+- **Dependency direction is `entrypoints → lib` only; `lib` never imports from
+  `entrypoints`.** `src/lib/` stays reusable and unit-testable in isolation
+  (with `installChromeFake` from `src/lib/testing/chromeFake.ts`); a back-edge would
+  couple shared code to one surface.
+- **Entrypoints do not import each other directly.** Surfaces are separate runtime
+  contexts (popup / options / background / content); they communicate through the
+  typed messaging layer in `src/lib/messaging/`, not shared module state.
+- **Real `chrome.*` access lives only inside `src/lib/`.** Outside `src/lib/**`,
+  referencing the `chrome` global is an Oxlint error (`no-restricted-globals` /
+  `no-restricted-properties` override in `.oxlintrc.json`); route the call through a
+  thin `src/lib/` wrapper instead. Type-only references via the `chrome` namespace
+  (`@types/chrome`) are allowed everywhere. An unavoidable exception must carry a
+  reasoned `oxlint-disable` comment so the boundary violation stays visible.
+
+## Recipes
+
+Minimal, real code paths for the common changes. Finish each with `npm run verify`.
+
+- **Add a message type.** In `src/lib/messaging/messages.ts`, add one entry to
+  `messages` via `defineMessage(isRequest, isResponse)` (hand-written type-guard
+  predicates — no runtime schema dependency). Register the handler in
+  `src/entrypoints/background/background.ts` under `addMessageListeners({ ... })`, and
+  send from a surface with `sendMessage(name, payload)`. The generic engine in
+  `createMessaging.ts` needs no change; sender check and payload guards are automatic.
+- **Add a storage key.** In `src/lib/storage/schema.ts`, add the key to the
+  `AppStorageValues` type and to `storageSchema` (`area` + `defaultValue`). Everything
+  else (`getStorageValue` / `setStorageValue` / `removeStorageValue` /
+  `onStorageValueChanged` / `useStorageValue`) is generic and follows automatically.
+- **Add a Chrome permission.** Add it to `permissions` (or `host_permissions` /
+  `optional_permissions`) in `manifest.config.ts`, **and** update the matching
+  allowlist (`EXPECTED_PERMISSIONS`, `EXPECTED_HOST_PERMISSIONS`, …) in
+  `scripts/verify-manifest.mjs`. A mismatch makes `verify:manifest` fail by design —
+  that failure is the guard against silent privilege growth.
+
+## Forbidden changes
+
+Do not make these without explicit owner sign-off. Most are enforced by
+`scripts/verify-manifest.mjs`, which fails the build on violation:
+
+- Adding a manifest `permission` / `host_permission` without updating the
+  `verify-manifest.mjs` allowlist (and without a reason to hold the new privilege).
+- Adding an external runtime dependency to `src/lib/` — the messaging and storage
+  layers are dependency-free by design; keep them so.
+- Relaxing the CSP. `verify:manifest` pins
+  `content_security_policy.extension_pages` to `script-src 'self'; object-src 'self';`.
+- Declaring `externally_connectable` — `verify:manifest` rejects it outright.
 
 ## Conventions
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "prepare": "husky",
     "dev": "vite",
     "build": "rm -rf extension && vite build",
+    "verify": "npm run check-type && npm run lint && npm run test && npm run build && npm run verify:manifest",
+    "verify:full": "npm run verify && npm run e2e",
     "verify:manifest": "node scripts/verify-manifest.mjs",
     "verify:release-version": "node scripts/verify-release-version.mjs",
     "e2e": "playwright test",


### PR DESCRIPTION
Closes #38

## 背景

親ロードマップ #41 の目標状態「AI コーディングエージェントが安全に変更できる設計契約と検証契約がある」を満たすための対応。従来はアーキテクチャの不変条件・定型変更手順・禁止変更が `AGENTS.md` / `.claude/rules/` / README に断片化しており、検証コマンドも `check-type` / `lint` / `test` / `build` / `verify:manifest` / `e2e` に分散していた。

前提 Issue #31(chrome 境界の lint 強制)・#33(実 Chromium E2E)はいずれも完了済みのため、e2e を利用できる。Issue が残していた選択(e2e を verify に含めるか)については、**`verify`(e2e 除外)と `verify:full`(e2e 込み)の両方**を用意する方針とした。

## 変更内容

### `package.json` — verify 一括コマンド
- `verify` = `check-type → lint → test → build → verify:manifest` を直列連鎖。`verify:manifest` は build 成果物(`extension/manifest.json`)を読むため build の後段に固定。
- `verify:full` = `verify` + `e2e`。実 Chromium 検証を分離。
- `format`(整形書き換え)は CI と同じく含めない(検査のみ)。

### `AGENTS.md` — 設計契約・検証契約を明文化(英語)
- **Verification contract**: `verify` / `verify:full` の定義と、変更種別ごとの最低限の検証表。
- **Architecture invariants**: `entrypoints → lib` の依存方向、entrypoints 間の直接 import 禁止(messaging 経由)、`chrome.*` の実参照は `src/lib/` 内のみ(Oxlint で強制)。それぞれ「なぜ境界があるか」を付記。
- **Recipes**: 実在コードパスを指す最小手順(メッセージ型追加=`src/lib/messaging/messages.ts` / storage キー追加=`src/lib/storage/schema.ts` / 権限追加=`manifest.config.ts` + `scripts/verify-manifest.mjs` の許可リスト同期)。
- **Forbidden changes**: 権限の無断追加、`src/lib/` への外部依存追加、CSP 緩和、`externally_connectable` 宣言。いずれも可能な範囲で `verify:manifest` が機械検査する旨を明記。

方針として、規約の正は lint ルール・型・検証スクリプト側に置き、AGENTS.md はそれらへの案内と機械化できない意図の説明に徹する(実装との二重管理を避ける)。

### 変更しないもの
- `CLAUDE.md` は既に `@AGENTS.md` を参照済み(受け入れ条件を充足)。
- README「AI開発設定」節も既に `AGENTS.md` を参照済み。Issue 方針に沿い本文は書き換えない。
- CI 構成(既に同一チェックを個別ジョブで実行済み)。

## 受け入れ条件の確認

- [x] `npm run verify` が一括で green(check-type / lint / 28 tests / build / verify:manifest すべて通過)。
- [x] AGENTS.md の「新しいメッセージ型の追加」レシピを試行ブランチで実演 → `verify` green → 破棄まで手順どおり完結。
- [x] AGENTS.md 内で参照する全ファイルパス・コマンド・許可リストシンボルが実在することを機械確認。
- [x] `CLAUDE.md` から `AGENTS.md` が参照されている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmMyRvFtVE5JwagQM2fBb5)_