### PR TITLE
docs: confirm PVR as the permanent CoC enforcement contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,16 +51,13 @@ when an individual is officially representing the community in public spaces.
 
 ## Enforcement
 
-A dedicated private contact channel for Code of Conduct reports is not yet
-published; tracked in
-[#58](https://github.com/50ra4/crx-vite-ts-react-template/issues/58). Until it
-is set up, please report instances of abusive, harassing, or otherwise
-unacceptable behavior privately through GitHub's [Private Vulnerability
-Reporting](./SECURITY.md) (repository's **Security** tab → **Report a
-vulnerability**) rather than a public issue — this keeps the report
-confidential between you and the maintainer even though the feature is
-named for security issues. All complaints will be reviewed and investigated
-promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement privately
+through GitHub's [Private Vulnerability Reporting](./SECURITY.md) (repository's
+**Security** tab → **Report a vulnerability**) rather than a public issue —
+this keeps the report confidential between you and the maintainer even though
+the feature is named for security issues. All complaints will be reviewed and
+investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
## Summary

`CODE_OF_CONDUCT.md` の Enforcement 節にあった暫定連絡先(「専用連絡先は準備中・#58 で追跡」)を確定した。新規の公開メールアドレスは設けず、GitHub Private Vulnerability Reporting (PVR) を CoC 違反報告の**正式・恒久の窓口**とする。

- 「not yet published / tracked in #58」という暫定フレーミングを削除。
- 文言を Contributor Covenant 標準の "may be reported to the community leaders responsible for enforcement ..." 型に寄せつつ、PVR への導線(Security タブ → Report a vulnerability、`./SECURITY.md` リンク)を維持。
- SECURITY.md と報告経路が一致し、公開メール不要で GitHub Community Standards も充足。

## Related issue

Closes #58

## Verification

ドキュメントのみの変更で実装への影響はゼロ。

- [x] `npx prettier --check CODE_OF_CONDUCT.md`(整形崩れなし)
- [ ] `npm run check-type`
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm run e2e` (if applicable)

## Breaking changes

- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wwS8jea1rSWmEsjXA7uRc)_