### PR TITLE
feat: 拡張機能の表示名を package name から分離する

### DIFF
--- a/.claude/rules/chrome-extension.md
+++ b/.claude/rules/chrome-extension.md
@@ -7,8 +7,8 @@ MV3 facts specific to this repo:
 - `src/entrypoints/background/background.ts` is a service worker — no DOM, no `window`.
 - All manifest changes go through `manifest.config.ts` (`defineManifest`); never hand-edit a raw `manifest.json`.
 - Dev vs. build differ in `manifest.config.ts`: the extension name is prefixed
-  `[DEV] ${name}` when `command === 'serve'`, and icon filenames get a `-dev`
-  suffix (`createIconFileSuffix`).
+  `[DEV] ${displayName}` when `command === 'serve'`, and icon filenames get a
+  `-dev` suffix (`createIconFileSuffix`).
 - Stable package versions are copied to manifest `version`. For prereleases,
   manifest `version` uses the numeric SemVer core and `version_name` preserves
   the complete package version because Chrome rejects prerelease text in `version`.

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -5,9 +5,12 @@ description: Turn this template into a real Chrome extension project. Use when s
 
 Checklist:
 
-- **`package.json`**: update `name`, `description`, `repository`, `bugs`,
-  `homepage`, `author`. `manifest.config.ts` derives the extension `name`
-  and `version` from here, so this is enough to rename the built extension.
+- **`package.json`**: update `name` (the kebab-case npm package identifier),
+  `displayName` (the human-readable Chrome product name), `description`,
+  `repository`, `bugs`, `homepage`, `author`. `manifest.config.ts` derives the
+  extension `name` from `displayName` and its version from `version`.
+  `npm run verify:manifest` warns while `displayName` still has the template
+  default.
 - **`manifest.config.ts`**: fill in `description` (currently empty), review
   `permissions` (currently just `['background']`), and review
   `content_scripts[].matches` — the template ships with a sample match on

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ and can be loaded unpacked the same way.
 
 The manifest is not written by hand: it is generated from
 [`manifest.config.ts`](./manifest.config.ts) by `@crxjs/vite-plugin` at
-build time. In dev mode the extension name gets a `[DEV]` prefix and the dev
-icon set is used, so a dev build and a production install can coexist.
+build time. The Chrome display name comes from `package.json`'s `displayName`,
+independently of the kebab-case npm package `name`. In dev mode the display
+name gets a `[DEV]` prefix and the dev icon set is used, so a dev build and a
+production install can coexist.
 `index.html` is a dev-only launcher page linking to the popup and options
 pages; it is not part of the extension.
 
@@ -187,8 +189,11 @@ The template separates reusable infrastructure (`src/lib/`) from sample code:
 1. Delete `src/examples/` entirely — nothing outside it imports from it.
 2. Replace the sample UI in `src/entrypoints/` (popup / options / content) and
    the `greet` sample message with your own features.
-3. Update `package.json` (name, description, repository), the manifest
-   description in `manifest.config.ts`, and the icons in `public/logo/`.
+3. Update `package.json` (`name` for the npm package, `displayName` for the
+   human-readable Chrome product name, plus description and repository), the
+   manifest description in `manifest.config.ts`, and the icons in
+   `public/logo/`. `npm run verify:manifest` warns while `displayName` still
+   has the template default.
 4. Adjust or remove the content script `matches` (`https://example.com/*`) in
    `manifest.config.ts` — and mirror the change in
    `scripts/verify-manifest.mjs` (see below).

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -101,10 +101,11 @@ unpacked 読み込みして確認できます。
 | Content script | `src/entrypoints/content/sample.tsx`       | `https://example.com/*` に注入(`manifest.config.ts` 参照)。               |
 
 manifest は手書きではなく、[`manifest.config.ts`](../manifest.config.ts) から
-`@crxjs/vite-plugin` がビルド時に生成します。dev モードでは拡張名に `[DEV]`
-接頭辞が付き、dev 用アイコンが使われるため、開発ビルドと本番インストールを
-共存させられます。`index.html` は popup / options へのリンクを持つ dev 専用の
-ランチャーページで、拡張本体には含まれません。
+`@crxjs/vite-plugin` がビルド時に生成します。Chrome の表示名は kebab-case の
+npm パッケージ `name` とは独立した `package.json` の `displayName` から取得します。
+dev モードでは表示名に `[DEV]` 接頭辞が付き、dev 用アイコンが使われるため、
+開発ビルドと本番インストールを共存させられます。`index.html` は popup / options
+へのリンクを持つ dev 専用のランチャーページで、拡張本体には含まれません。
 
 DevTools パネルのサーフェスは意図的に含めていません。必要な場合は
 [chrome.devtools 公式ドキュメント](https://developer.chrome.com/docs/extensions/reference/api/devtools)
@@ -183,8 +184,10 @@ src/
 1. `src/examples/` を丸ごと削除します。外部から import されていません。
 2. `src/entrypoints/` のサンプル UI(popup / options / content)と `greet`
    サンプルメッセージを自分の機能に置き換えます。
-3. `package.json`(name、description、repository)、`manifest.config.ts` の
-   説明、`public/logo/` のアイコンを更新します。
+3. `package.json` の npm パッケージ用 `name`、Chrome の人間可読な製品名用
+   `displayName`、description、repository を更新し、`manifest.config.ts` の
+   説明と `public/logo/` のアイコンも更新します。`displayName` がテンプレートの
+   既定値のままなら `npm run verify:manifest` が警告します。
 4. `manifest.config.ts` の content script `matches`(`https://example.com/*`)を
    変更または削除し、`scripts/verify-manifest.mjs` にも同じ変更を反映します
    (次節参照)。

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -1,13 +1,10 @@
 import { defineManifest } from '@crxjs/vite-plugin';
-import { name, version } from './package.json';
+import { displayName, version } from './package.json';
+import { createExtensionNames } from './scripts/extension-name.mjs';
 import { createManifestVersion } from './scripts/manifest-version.mjs';
 
 const manifestVersion = createManifestVersion(version);
-
-const EXTENSION_NAMES = {
-  build: name,
-  serve: `[DEV] ${name}`,
-} as const;
+const EXTENSION_NAMES = createExtensionNames(displayName);
 
 const createIconFileSuffix = (command: 'build' | 'serve') =>
   command === 'serve' ? '-dev' : '';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "crx-vite-ts-react-template",
+  "displayName": "CRX Vite TS React Template",
   "version": "1.0.0",
   "description": "Chrome extension template using Vite, TypeScript and React",
   "main": "index.js",

--- a/scripts/extension-name.d.mts
+++ b/scripts/extension-name.d.mts
@@ -1,0 +1,18 @@
+export const TEMPLATE_EXTENSION_DISPLAY_NAME: string;
+
+export type ExtensionNames = {
+  build: string;
+  serve: string;
+};
+
+export type ExtensionDisplayNameValidation = {
+  errors: string[];
+  warnings: string[];
+};
+
+export const createExtensionNames: (displayName: string) => ExtensionNames;
+
+export const validateExtensionDisplayName: (input: {
+  displayName: unknown;
+  manifestName: unknown;
+}) => ExtensionDisplayNameValidation;

--- a/scripts/extension-name.mjs
+++ b/scripts/extension-name.mjs
@@ -1,0 +1,30 @@
+export const TEMPLATE_EXTENSION_DISPLAY_NAME = 'CRX Vite TS React Template';
+
+export const createExtensionNames = (displayName) => ({
+  build: displayName,
+  serve: `[DEV] ${displayName}`,
+});
+
+export const validateExtensionDisplayName = ({ displayName, manifestName }) => {
+  const errors = [];
+  const warnings = [];
+
+  if (typeof displayName !== 'string' || displayName.trim().length === 0) {
+    errors.push('package.json displayName must be a non-empty string.');
+    return { errors, warnings };
+  }
+
+  if (manifestName !== displayName) {
+    errors.push(
+      `name must equal package.json displayName ${JSON.stringify(displayName)}; received ${JSON.stringify(manifestName)}.`,
+    );
+  }
+
+  if (displayName === TEMPLATE_EXTENSION_DISPLAY_NAME) {
+    warnings.push(
+      `package.json displayName is still the template default ${JSON.stringify(TEMPLATE_EXTENSION_DISPLAY_NAME)}; set the product display name before release.`,
+    );
+  }
+
+  return { errors, warnings };
+};

--- a/scripts/extension-name.test.mjs
+++ b/scripts/extension-name.test.mjs
@@ -1,0 +1,60 @@
+// @vitest-environment node
+
+import {
+  TEMPLATE_EXTENSION_DISPLAY_NAME,
+  createExtensionNames,
+  validateExtensionDisplayName,
+} from './extension-name.mjs';
+
+test('creates production and development names from the display name', () => {
+  expect(createExtensionNames('Readable Product Name')).toEqual({
+    build: 'Readable Product Name',
+    serve: '[DEV] Readable Product Name',
+  });
+});
+
+test('accepts a manifest name that matches a custom display name', () => {
+  expect(
+    validateExtensionDisplayName({
+      displayName: 'Readable Product Name',
+      manifestName: 'Readable Product Name',
+    }),
+  ).toEqual({ errors: [], warnings: [] });
+});
+
+test.each([undefined, '', '   '])(
+  'rejects an invalid package display name: %s',
+  (displayName) => {
+    expect(
+      validateExtensionDisplayName({
+        displayName,
+        manifestName: 'Readable Product Name',
+      }).errors,
+    ).toEqual(['package.json displayName must be a non-empty string.']);
+  },
+);
+
+test('rejects a manifest name that differs from the package display name', () => {
+  expect(
+    validateExtensionDisplayName({
+      displayName: 'Readable Product Name',
+      manifestName: 'package-name',
+    }).errors,
+  ).toEqual([
+    'name must equal package.json displayName "Readable Product Name"; received "package-name".',
+  ]);
+});
+
+test('warns when the display name is still the template default', () => {
+  expect(
+    validateExtensionDisplayName({
+      displayName: TEMPLATE_EXTENSION_DISPLAY_NAME,
+      manifestName: TEMPLATE_EXTENSION_DISPLAY_NAME,
+    }),
+  ).toEqual({
+    errors: [],
+    warnings: [
+      'package.json displayName is still the template default "CRX Vite TS React Template"; set the product display name before release.',
+    ],
+  });
+});

--- a/scripts/verify-manifest.mjs
+++ b/scripts/verify-manifest.mjs
@@ -2,6 +2,7 @@ import { readFile, stat } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { validateExtensionDisplayName } from './extension-name.mjs';
 import { createManifestVersion } from './manifest-version.mjs';
 
 const EXPECTED_CSP = "script-src 'self'; object-src 'self';";
@@ -17,6 +18,7 @@ const extensionDirectory = fileURLToPath(
 const manifestPath = resolve(extensionDirectory, 'manifest.json');
 const packagePath = fileURLToPath(new URL('../package.json', import.meta.url));
 const errors = [];
+const warnings = [];
 const references = [];
 
 const isRecord = (value) =>
@@ -96,6 +98,12 @@ if (!isRecord(packageJson) || typeof packageJson.version !== 'string') {
 }
 
 const expectedManifestVersion = createManifestVersion(packageJson.version);
+const extensionDisplayNameValidation = validateExtensionDisplayName({
+  displayName: packageJson.displayName,
+  manifestName: manifest.name,
+});
+errors.push(...extensionDisplayNameValidation.errors);
+warnings.push(...extensionDisplayNameValidation.warnings);
 
 report(
   manifest.version === expectedManifestVersion.version,
@@ -241,6 +249,12 @@ const verifyReference = async ({ field, value }) => {
 
 const referenceErrors = await Promise.all(references.map(verifyReference));
 errors.push(...referenceErrors.filter(Boolean));
+
+if (warnings.length > 0) {
+  console.warn(
+    `Manifest verification warnings:\n${warnings.map((warning) => `- ${warning}`).join('\n')}`,
+  );
+}
 
 if (errors.length > 0) {
   console.error(


### PR DESCRIPTION
## 概要

- `package.json.displayName` を導入し、Chrome の表示名を npm package `name` から分離
- dev ビルドの `[DEV]` プレフィックスを維持
- テンプレート既定名のままの場合に `verify:manifest` で警告
- README（日英）と `adapt-template` スキルへ設定手順を追加

## 背景

npm の kebab-case パッケージ名を Chrome の製品表示名として流用すると、派生プロジェクトで人間可読な表示名への変更が漏れるためです。

## 影響

派生プロジェクトは npm package `name` を維持したまま、`displayName` だけで Chrome の表示名を設定できます。

## 検証

- TDD: RED 6件失敗 → GREEN 7件成功
- `npm run verify`
  - TypeScript: 成功
  - Oxlint: 成功
  - Vitest: 11ファイル / 35テスト成功
  - production build: 成功
  - manifest verification: 成功（テンプレート既定名の意図した警告あり）
- 生成結果: `package name != displayName == manifest name`

Closes #123