### PR TITLE
feat: verify-manifest を宣言的な期待値定義に再設計

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,23 +92,28 @@ blanket command.
   The schema edit is `src/lib/**`-only, so **`npm run verify`** covers it; if you also
   wire a surface to read or write the key, verify that with `npm run verify:full`.
 - **Add a Chrome permission.** Add it to `permissions` (or `host_permissions` /
-  `optional_permissions`) in `manifest.config.ts`, **and** update the matching
-  allowlist (`EXPECTED_PERMISSIONS`, `EXPECTED_HOST_PERMISSIONS`, …) in
-  `scripts/verify-manifest.mjs`. A mismatch makes `verify:manifest` fail by design —
-  that failure is the guard against silent privilege growth. **`npm run verify`** asserts it.
+  `optional_permissions`) in `manifest.config.ts`, **and** update the matching array
+  in `scripts/expected-manifest.config.mjs`. A mismatch makes `verify:manifest` fail
+  by design — that failure is the guard against silent privilege growth. Surface,
+  content-script, and web-accessible-resource expectations live in the same file;
+  do not modify the generic engine for a product-specific manifest shape.
+  **`npm run verify`** asserts it.
 
 ## Forbidden changes
 
 Do not make these without explicit owner sign-off. Most are enforced by
 `scripts/verify-manifest.mjs`, which fails the build on violation:
 
-- Adding a manifest `permission` / `host_permission` without updating the
-  `verify-manifest.mjs` allowlist (and without a reason to hold the new privilege).
+- Adding a manifest `permission` / `host_permission` without updating the matching
+  array in `scripts/expected-manifest.config.mjs` (and without a reason to hold the
+  new privilege).
 - Adding an external runtime dependency to `src/lib/` — the messaging and storage
   layers are dependency-free by design; keep them so.
-- Relaxing the CSP. `verify:manifest` pins
-  `content_security_policy.extension_pages` to `script-src 'self'; object-src 'self';`.
-- Declaring `externally_connectable` — `verify:manifest` rejects it outright.
+- Relaxing the CSP. The generic engine pins
+  `content_security_policy.extension_pages` to `script-src 'self'; object-src 'self';`;
+  `expected-manifest.config.mjs` cannot override it.
+- Declaring `externally_connectable` — the generic engine rejects it outright, and
+  `expected-manifest.config.mjs` cannot permit it.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ The template separates reusable infrastructure (`src/lib/`) from sample code:
    has the template default.
 4. Adjust or remove the content script `matches` (`https://example.com/*`) in
    `manifest.config.ts` — and mirror the change in
-   `scripts/verify-manifest.mjs` (see below).
+   `scripts/expected-manifest.config.mjs` (see below). The same expectation file
+   declares which extension surfaces and web-accessible resources must be present.
 
 `.claude/skills/adapt-template/SKILL.md` contains the full checklist.
 
@@ -206,14 +207,15 @@ Permissions are guarded against silent growth:
 
 1. Add the permission to `permissions` (or `host_permissions` /
    `optional_permissions`) in `manifest.config.ts`.
-2. Update the matching allowlist (`EXPECTED_PERMISSIONS`,
-   `EXPECTED_HOST_PERMISSIONS`, …) in `scripts/verify-manifest.mjs`.
+2. Update the matching array (`permissions`, `host_permissions`, …) in
+   `scripts/expected-manifest.config.mjs`.
 3. Run `npm run verify` — a mismatch between the built manifest and the
-   allowlists fails `verify:manifest` **by design**, so every privilege change
+   expectations fails `verify:manifest` **by design**, so every privilege change
    shows up as a reviewable diff.
 
-The same script pins the CSP to `script-src 'self'; object-src 'self';` and
-rejects `externally_connectable`.
+The generic verification engine pins the CSP to
+`script-src 'self'; object-src 'self';` and rejects `externally_connectable`;
+the expectation file cannot relax either invariant.
 
 ## Packaging and release
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -189,8 +189,9 @@ src/
    説明と `public/logo/` のアイコンも更新します。`displayName` がテンプレートの
    既定値のままなら `npm run verify:manifest` が警告します。
 4. `manifest.config.ts` の content script `matches`(`https://example.com/*`)を
-   変更または削除し、`scripts/verify-manifest.mjs` にも同じ変更を反映します
-   (次節参照)。
+   変更または削除し、`scripts/expected-manifest.config.mjs` にも同じ変更を
+   反映します(次節参照)。同じ期待値ファイルで、必要な拡張機能サーフェスと
+   web accessible resources も宣言します。
 
 完全なチェックリストは `.claude/skills/adapt-template/SKILL.md` にあります。
 
@@ -200,14 +201,15 @@ src/
 
 1. `manifest.config.ts` の `permissions`(または `host_permissions` /
    `optional_permissions`)に権限を追加します。
-2. `scripts/verify-manifest.mjs` の対応する許可リスト
-   (`EXPECTED_PERMISSIONS`、`EXPECTED_HOST_PERMISSIONS` など)を更新します。
-3. `npm run verify` を実行します。ビルド成果物の manifest と許可リストの不一致で
+2. `scripts/expected-manifest.config.mjs` の対応する配列
+   (`permissions`、`host_permissions` など)を更新します。
+3. `npm run verify` を実行します。ビルド成果物の manifest と期待値の不一致で
    `verify:manifest` が失敗するのは**仕様**であり、すべての権限変更が
    レビュー可能な diff として現れます。
 
-同スクリプトは CSP を `script-src 'self'; object-src 'self';` に固定し、
-`externally_connectable` の宣言を拒否します。
+汎用検証エンジンは CSP を `script-src 'self'; object-src 'self';` に固定し、
+`externally_connectable` の宣言を拒否します。期待値ファイルからこの不変条件を
+緩和することはできません。
 
 ## Packaging and release
 

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -34,7 +34,7 @@ export default defineManifest(({ command }) => ({
       }
     : {}),
   // Declare only permissions for Chrome APIs that the extension actually uses.
-  // Keep the allowlists in scripts/verify-manifest.mjs in sync when adding one.
+  // Keep scripts/expected-manifest.config.mjs in sync when adding one.
   permissions: ['storage'],
   content_scripts: [
     {

--- a/scripts/expected-manifest.config.mjs
+++ b/scripts/expected-manifest.config.mjs
@@ -1,0 +1,31 @@
+const CONCRETE_JS_ASSET = /^assets\/[^*?[\]{}]+\.js$/u;
+const CONTENT_SCRIPT_MATCHES = ['https://example.com/*'];
+
+export const expectedManifest = {
+  permissions: ['storage'],
+  host_permissions: [],
+  optional_permissions: [],
+  optional_host_permissions: [],
+  surfaces: {
+    action: true,
+    options_ui: true,
+    background: true,
+  },
+  content_scripts: [
+    {
+      matches: CONTENT_SCRIPT_MATCHES,
+      run_at: 'document_idle',
+    },
+  ],
+  web_accessible_resources: [
+    {
+      matches: CONTENT_SCRIPT_MATCHES,
+      extension_ids: [],
+      use_dynamic_url: false,
+      resources: {
+        required: [],
+        allowedPatterns: [CONCRETE_JS_ASSET],
+      },
+    },
+  ],
+};

--- a/scripts/expected-manifest.config.mjs
+++ b/scripts/expected-manifest.config.mjs
@@ -7,7 +7,10 @@ export const expectedManifest = {
   optional_permissions: [],
   optional_host_permissions: [],
   surfaces: {
-    action: true,
+    action: {
+      present: true,
+      default_popup: true,
+    },
     options_ui: true,
     background: true,
   },

--- a/scripts/verify-manifest-engine.mjs
+++ b/scripts/verify-manifest-engine.mjs
@@ -1,0 +1,355 @@
+import { stat } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+import { validateExtensionDisplayName } from './extension-name.mjs';
+import { createManifestVersion } from './manifest-version.mjs';
+
+const REQUIRED_CSP = "script-src 'self'; object-src 'self';";
+
+const isRecord = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const verifyManifest = async ({
+  manifest,
+  packageJson,
+  expectedManifest,
+  extensionDirectory,
+}) => {
+  const errors = [];
+  const warnings = [];
+  const references = [];
+
+  const report = (condition, message) => {
+    if (!condition) errors.push(message);
+  };
+
+  const readStrings = (value, field) => {
+    if (
+      !Array.isArray(value) ||
+      !value.every((item) => typeof item === 'string')
+    ) {
+      errors.push(`${field} must be an array of strings.`);
+      return undefined;
+    }
+    return value;
+  };
+
+  const expectSet = (value, expected, field) => {
+    const values = readStrings(value ?? [], field);
+    const wanted = readStrings(expected, `expectedManifest.${field}`);
+    if (values === undefined || wanted === undefined) return;
+
+    const actual = values.toSorted();
+    const sortedExpected = wanted.toSorted();
+    report(
+      JSON.stringify(actual) === JSON.stringify(sortedExpected),
+      `${field} must equal ${JSON.stringify(sortedExpected)}; received ${JSON.stringify(actual)}.`,
+    );
+  };
+
+  const addReference = (value, field) => {
+    if (typeof value !== 'string' || value.length === 0) {
+      errors.push(`${field} must reference a non-empty path.`);
+      return;
+    }
+    references.push({ field, value });
+  };
+
+  const addIconReferences = (icons, field) => {
+    if (typeof icons === 'string') {
+      addReference(icons, field);
+    } else if (isRecord(icons)) {
+      for (const [size, path] of Object.entries(icons)) {
+        addReference(path, `${field}.${size}`);
+      }
+    } else {
+      errors.push(`${field} must be a path or an icon-size map.`);
+    }
+  };
+
+  if (!isRecord(manifest)) {
+    return {
+      errors: ['manifest must be an object.'],
+      warnings,
+    };
+  }
+
+  if (!isRecord(packageJson) || typeof packageJson.version !== 'string') {
+    return {
+      errors: ['package.json version must be a string.'],
+      warnings,
+    };
+  }
+
+  if (!isRecord(expectedManifest)) {
+    return {
+      errors: ['expectedManifest must be an object.'],
+      warnings,
+    };
+  }
+
+  const expectedManifestVersion = createManifestVersion(packageJson.version);
+  const extensionDisplayNameValidation = validateExtensionDisplayName({
+    displayName: packageJson.displayName,
+    manifestName: manifest.name,
+  });
+  errors.push(...extensionDisplayNameValidation.errors);
+  warnings.push(...extensionDisplayNameValidation.warnings);
+
+  report(
+    manifest.version === expectedManifestVersion.version,
+    `version must equal ${JSON.stringify(expectedManifestVersion.version)}; received ${JSON.stringify(manifest.version)}.`,
+  );
+  report(
+    manifest.version_name === expectedManifestVersion.version_name,
+    `version_name must equal ${JSON.stringify(expectedManifestVersion.version_name)}; received ${JSON.stringify(manifest.version_name)}.`,
+  );
+  report(
+    manifest.manifest_version === 3,
+    `manifest_version must be 3; received ${JSON.stringify(manifest.manifest_version)}.`,
+  );
+
+  for (const field of [
+    'permissions',
+    'host_permissions',
+    'optional_permissions',
+    'optional_host_permissions',
+  ]) {
+    expectSet(manifest[field], expectedManifest[field], field);
+  }
+
+  report(
+    manifest.externally_connectable === undefined,
+    'externally_connectable must not be declared.',
+  );
+  const csp = manifest.content_security_policy?.extension_pages;
+  report(
+    csp === REQUIRED_CSP,
+    `content_security_policy.extension_pages must equal ${JSON.stringify(REQUIRED_CSP)}; received ${JSON.stringify(csp)}.`,
+  );
+
+  if (manifest.icons !== undefined) addIconReferences(manifest.icons, 'icons');
+  if (manifest.action?.default_icon !== undefined) {
+    addIconReferences(manifest.action.default_icon, 'action.default_icon');
+  }
+
+  const expectedSurfaces = expectedManifest.surfaces;
+  if (!isRecord(expectedSurfaces)) {
+    errors.push('expectedManifest.surfaces must be an object.');
+  } else {
+    for (const surface of ['action', 'options_ui', 'background']) {
+      const expected = expectedSurfaces[surface];
+      if (typeof expected !== 'boolean') {
+        errors.push(`expectedManifest.surfaces.${surface} must be a boolean.`);
+        continue;
+      }
+
+      if (!expected) {
+        report(
+          manifest[surface] === undefined,
+          `${surface} must not be declared.`,
+        );
+        continue;
+      }
+
+      report(isRecord(manifest[surface]), `${surface} must be declared.`);
+      if (!isRecord(manifest[surface])) continue;
+
+      const referenceFields = {
+        action: 'default_popup',
+        options_ui: 'page',
+        background: 'service_worker',
+      };
+      const referenceField = referenceFields[surface];
+      addReference(
+        manifest[surface][referenceField],
+        `${surface}.${referenceField}`,
+      );
+    }
+  }
+
+  const expectedContentScripts = expectedManifest.content_scripts;
+  if (!Array.isArray(expectedContentScripts)) {
+    errors.push('expectedManifest.content_scripts must be an array.');
+  }
+  report(
+    Array.isArray(manifest.content_scripts ?? []),
+    'content_scripts must be an array.',
+  );
+  const contentScripts = Array.isArray(manifest.content_scripts)
+    ? manifest.content_scripts
+    : [];
+  const contentScriptExpectations = Array.isArray(expectedContentScripts)
+    ? expectedContentScripts
+    : [];
+  report(
+    contentScripts.length === contentScriptExpectations.length,
+    `content_scripts must contain exactly ${contentScriptExpectations.length} entries; received ${contentScripts.length}.`,
+  );
+
+  contentScripts.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`content_scripts.${index} must be an object.`);
+      return;
+    }
+
+    const expectation = contentScriptExpectations[index];
+    if (!isRecord(expectation)) {
+      errors.push(
+        `expectedManifest.content_scripts.${index} must be an object.`,
+      );
+    } else {
+      expectSet(
+        entry.matches,
+        expectation.matches,
+        `content_scripts.${index}.matches`,
+      );
+      report(
+        (entry.run_at ?? 'document_idle') === expectation.run_at,
+        `content_scripts.${index}.run_at must equal ${JSON.stringify(expectation.run_at)}; received ${JSON.stringify(entry.run_at ?? 'document_idle')}.`,
+      );
+    }
+
+    for (const field of ['js', 'css']) {
+      if (entry[field] === undefined) continue;
+      const paths =
+        readStrings(entry[field], `content_scripts.${index}.${field}`) ?? [];
+      paths.forEach((path, pathIndex) =>
+        addReference(path, `content_scripts.${index}.${field}.${pathIndex}`),
+      );
+    }
+  });
+
+  const expectedWebAccessibleResources =
+    expectedManifest.web_accessible_resources;
+  if (!Array.isArray(expectedWebAccessibleResources)) {
+    errors.push('expectedManifest.web_accessible_resources must be an array.');
+  }
+  report(
+    Array.isArray(manifest.web_accessible_resources ?? []),
+    'web_accessible_resources must be an array.',
+  );
+  const webAccessibleResources = Array.isArray(
+    manifest.web_accessible_resources,
+  )
+    ? manifest.web_accessible_resources
+    : [];
+  const webAccessibleResourceExpectations = Array.isArray(
+    expectedWebAccessibleResources,
+  )
+    ? expectedWebAccessibleResources
+    : [];
+  report(
+    webAccessibleResources.length === webAccessibleResourceExpectations.length,
+    `web_accessible_resources must contain exactly ${webAccessibleResourceExpectations.length} entries; received ${webAccessibleResources.length}.`,
+  );
+
+  webAccessibleResources.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`web_accessible_resources.${index} must be an object.`);
+      return;
+    }
+
+    const expectation = webAccessibleResourceExpectations[index];
+    if (!isRecord(expectation)) {
+      errors.push(
+        `expectedManifest.web_accessible_resources.${index} must be an object.`,
+      );
+      return;
+    }
+
+    expectSet(
+      entry.matches,
+      expectation.matches,
+      `web_accessible_resources.${index}.matches`,
+    );
+    expectSet(
+      entry.extension_ids,
+      expectation.extension_ids,
+      `web_accessible_resources.${index}.extension_ids`,
+    );
+    report(
+      entry.use_dynamic_url === expectation.use_dynamic_url,
+      `web_accessible_resources.${index}.use_dynamic_url must equal ${JSON.stringify(expectation.use_dynamic_url)}; received ${JSON.stringify(entry.use_dynamic_url)}.`,
+    );
+
+    const field = `web_accessible_resources.${index}.resources`;
+    const resources = readStrings(entry.resources, field) ?? [];
+    report(resources.length > 0, `${field} must not be empty.`);
+
+    const resourceExpectation = expectation.resources;
+    if (!isRecord(resourceExpectation)) {
+      errors.push(
+        `expectedManifest.web_accessible_resources.${index}.resources must be an object.`,
+      );
+      return;
+    }
+    const required =
+      readStrings(
+        resourceExpectation.required,
+        `expectedManifest.web_accessible_resources.${index}.resources.required`,
+      ) ?? [];
+    const allowedPatterns = resourceExpectation.allowedPatterns;
+    if (
+      !Array.isArray(allowedPatterns) ||
+      !allowedPatterns.every((pattern) => pattern instanceof RegExp)
+    ) {
+      errors.push(
+        `expectedManifest.web_accessible_resources.${index}.resources.allowedPatterns must be an array of regular expressions.`,
+      );
+      return;
+    }
+
+    for (const requiredPath of required) {
+      const count = resources.filter((path) => path === requiredPath).length;
+      report(
+        count === 1,
+        `${field} must contain ${requiredPath} exactly once; received ${count}.`,
+      );
+    }
+
+    resources.forEach((path, pathIndex) => {
+      const resourceField = `${field}.${pathIndex}`;
+      const allowed =
+        required.includes(path) ||
+        allowedPatterns.some((pattern) => {
+          pattern.lastIndex = 0;
+          return pattern.test(path);
+        });
+      report(
+        allowed,
+        `${resourceField} is not allowed by expectedManifest: ${path}`,
+      );
+      addReference(path, resourceField);
+    });
+  });
+
+  const verifyReference = async ({ field, value }) => {
+    const absolutePath = resolve(extensionDirectory, value);
+    const localPath = relative(extensionDirectory, absolutePath);
+    if (
+      isAbsolute(value) ||
+      /^[a-z][a-z0-9+.-]*:/iu.test(value) ||
+      localPath === '..' ||
+      localPath.startsWith('../') ||
+      localPath.startsWith('..\\') ||
+      isAbsolute(localPath)
+    ) {
+      return `${field} must stay within the extension directory: ${value}`;
+    }
+
+    try {
+      const file = await stat(absolutePath);
+      return file.isFile()
+        ? undefined
+        : `${field} does not reference a file: ${value}`;
+    } catch {
+      return `${field} references a missing file: ${value}`;
+    }
+  };
+
+  const referenceErrors = await Promise.all(references.map(verifyReference));
+  errors.push(...referenceErrors.filter(Boolean));
+
+  return { errors, warnings };
+};

--- a/scripts/verify-manifest-engine.mjs
+++ b/scripts/verify-manifest-engine.mjs
@@ -137,7 +137,45 @@ export const verifyManifest = async ({
   if (!isRecord(expectedSurfaces)) {
     errors.push('expectedManifest.surfaces must be an object.');
   } else {
-    for (const surface of ['action', 'options_ui', 'background']) {
+    const expectedAction = expectedSurfaces.action;
+    if (!isRecord(expectedAction)) {
+      errors.push('expectedManifest.surfaces.action must be an object.');
+    } else {
+      const { present, default_popup: defaultPopup } = expectedAction;
+      if (typeof present !== 'boolean') {
+        errors.push(
+          'expectedManifest.surfaces.action.present must be a boolean.',
+        );
+      }
+      if (typeof defaultPopup !== 'boolean') {
+        errors.push(
+          'expectedManifest.surfaces.action.default_popup must be a boolean.',
+        );
+      }
+      if (present === false && defaultPopup === true) {
+        errors.push(
+          'expectedManifest.surfaces.action.default_popup cannot be true when action.present is false.',
+        );
+      }
+
+      if (present === false) {
+        report(manifest.action === undefined, 'action must not be declared.');
+      } else if (present === true) {
+        report(isRecord(manifest.action), 'action must be declared.');
+        if (isRecord(manifest.action)) {
+          if (defaultPopup === true) {
+            addReference(manifest.action.default_popup, 'action.default_popup');
+          } else if (defaultPopup === false) {
+            report(
+              manifest.action.default_popup === undefined,
+              'action.default_popup must not be declared.',
+            );
+          }
+        }
+      }
+    }
+
+    for (const surface of ['options_ui', 'background']) {
       const expected = expectedSurfaces[surface];
       if (typeof expected !== 'boolean') {
         errors.push(`expectedManifest.surfaces.${surface} must be a boolean.`);
@@ -156,7 +194,6 @@ export const verifyManifest = async ({
       if (!isRecord(manifest[surface])) continue;
 
       const referenceFields = {
-        action: 'default_popup',
         options_ui: 'page',
         background: 'service_worker',
       };

--- a/scripts/verify-manifest.mjs
+++ b/scripts/verify-manifest.mjs
@@ -1,76 +1,15 @@
-import { readFile, stat } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { validateExtensionDisplayName } from './extension-name.mjs';
-import { createManifestVersion } from './manifest-version.mjs';
-
-const EXPECTED_CSP = "script-src 'self'; object-src 'self';";
-const EXPECTED_MATCHES = ['https://example.com/*'];
-const EXPECTED_PERMISSIONS = ['storage'];
-const EXPECTED_HOST_PERMISSIONS = [];
-const GLOB = /[*?[\]{}]/u;
-const CONCRETE_JS_ASSET = /^assets\/[^*?[\]{}]+\.js$/u;
+import { expectedManifest } from './expected-manifest.config.mjs';
+import { verifyManifest } from './verify-manifest-engine.mjs';
 
 const extensionDirectory = fileURLToPath(
   new URL('../extension/', import.meta.url),
 );
 const manifestPath = resolve(extensionDirectory, 'manifest.json');
 const packagePath = fileURLToPath(new URL('../package.json', import.meta.url));
-const errors = [];
-const warnings = [];
-const references = [];
-
-const isRecord = (value) =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const report = (condition, message) => {
-  if (!condition) errors.push(message);
-};
-
-const readStrings = (value, field) => {
-  if (
-    !Array.isArray(value) ||
-    !value.every((item) => typeof item === 'string')
-  ) {
-    errors.push(`${field} must be an array of strings.`);
-    return undefined;
-  }
-  return value;
-};
-
-const expectSet = (value, expected, field) => {
-  const values = readStrings(value ?? [], field);
-  if (values === undefined) return [];
-
-  const actual = values.toSorted();
-  const wanted = expected.toSorted();
-  report(
-    JSON.stringify(actual) === JSON.stringify(wanted),
-    `${field} must equal ${JSON.stringify(wanted)}; received ${JSON.stringify(actual)}.`,
-  );
-  return actual;
-};
-
-const addReference = (value, field) => {
-  if (typeof value !== 'string' || value.length === 0) {
-    errors.push(`${field} must reference a non-empty path.`);
-    return;
-  }
-  references.push({ field, value });
-};
-
-const addIconReferences = (icons, field) => {
-  if (typeof icons === 'string') {
-    addReference(icons, field);
-  } else if (isRecord(icons)) {
-    for (const [size, path] of Object.entries(icons)) {
-      addReference(path, `${field}.${size}`);
-    }
-  } else {
-    errors.push(`${field} must be a path or an icon-size map.`);
-  }
-};
 
 let manifest;
 let packageJson;
@@ -85,170 +24,12 @@ try {
   process.exit(1);
 }
 
-if (!isRecord(manifest)) {
-  console.error('Manifest verification failed:\n- manifest must be an object.');
-  process.exit(1);
-}
-
-if (!isRecord(packageJson) || typeof packageJson.version !== 'string') {
-  console.error(
-    'Manifest verification failed:\n- package.json version must be a string.',
-  );
-  process.exit(1);
-}
-
-const expectedManifestVersion = createManifestVersion(packageJson.version);
-const extensionDisplayNameValidation = validateExtensionDisplayName({
-  displayName: packageJson.displayName,
-  manifestName: manifest.name,
+const { errors, warnings } = await verifyManifest({
+  manifest,
+  packageJson,
+  expectedManifest,
+  extensionDirectory,
 });
-errors.push(...extensionDisplayNameValidation.errors);
-warnings.push(...extensionDisplayNameValidation.warnings);
-
-report(
-  manifest.version === expectedManifestVersion.version,
-  `version must equal ${JSON.stringify(expectedManifestVersion.version)}; received ${JSON.stringify(manifest.version)}.`,
-);
-report(
-  manifest.version_name === expectedManifestVersion.version_name,
-  `version_name must equal ${JSON.stringify(expectedManifestVersion.version_name)}; received ${JSON.stringify(manifest.version_name)}.`,
-);
-
-report(
-  manifest.manifest_version === 3,
-  `manifest_version must be 3; received ${JSON.stringify(manifest.manifest_version)}.`,
-);
-expectSet(manifest.permissions, EXPECTED_PERMISSIONS, 'permissions');
-expectSet(
-  manifest.host_permissions,
-  EXPECTED_HOST_PERMISSIONS,
-  'host_permissions',
-);
-expectSet(manifest.optional_permissions, [], 'optional_permissions');
-expectSet(manifest.optional_host_permissions, [], 'optional_host_permissions');
-report(
-  manifest.externally_connectable === undefined,
-  'externally_connectable must not be declared.',
-);
-
-const csp = manifest.content_security_policy?.extension_pages;
-report(
-  csp === EXPECTED_CSP,
-  `content_security_policy.extension_pages must equal ${JSON.stringify(EXPECTED_CSP)}; received ${JSON.stringify(csp)}.`,
-);
-
-if (manifest.icons !== undefined) addIconReferences(manifest.icons, 'icons');
-if (manifest.action?.default_icon !== undefined) {
-  addIconReferences(manifest.action.default_icon, 'action.default_icon');
-}
-if (manifest.action?.default_popup !== undefined) {
-  addReference(manifest.action.default_popup, 'action.default_popup');
-}
-if (manifest.options_ui?.page !== undefined) {
-  addReference(manifest.options_ui.page, 'options_ui.page');
-}
-if (manifest.background?.service_worker !== undefined) {
-  addReference(manifest.background.service_worker, 'background.service_worker');
-}
-
-report(
-  Array.isArray(manifest.content_scripts ?? []),
-  'content_scripts must be an array.',
-);
-const contentScripts = Array.isArray(manifest.content_scripts)
-  ? manifest.content_scripts
-  : [];
-contentScripts.forEach((entry, index) => {
-  if (!isRecord(entry)) {
-    errors.push(`content_scripts.${index} must be an object.`);
-    return;
-  }
-  expectSet(
-    entry.matches,
-    EXPECTED_MATCHES,
-    `content_scripts.${index}.matches`,
-  );
-  for (const field of ['js', 'css']) {
-    if (entry[field] === undefined) continue;
-    const paths =
-      readStrings(entry[field], `content_scripts.${index}.${field}`) ?? [];
-    paths.forEach((path, pathIndex) =>
-      addReference(path, `content_scripts.${index}.${field}.${pathIndex}`),
-    );
-  }
-});
-
-report(
-  Array.isArray(manifest.web_accessible_resources ?? []),
-  'web_accessible_resources must be an array.',
-);
-const webAccessibleResources = Array.isArray(manifest.web_accessible_resources)
-  ? manifest.web_accessible_resources
-  : [];
-webAccessibleResources.forEach((entry, index) => {
-  if (!isRecord(entry)) {
-    errors.push(`web_accessible_resources.${index} must be an object.`);
-    return;
-  }
-
-  expectSet(
-    entry.matches,
-    EXPECTED_MATCHES,
-    `web_accessible_resources.${index}.matches`,
-  );
-  expectSet(
-    entry.extension_ids,
-    [],
-    `web_accessible_resources.${index}.extension_ids`,
-  );
-  report(
-    typeof entry.use_dynamic_url === 'boolean',
-    `web_accessible_resources.${index}.use_dynamic_url must be explicit and boolean; received ${JSON.stringify(entry.use_dynamic_url)}.`,
-  );
-  const field = `web_accessible_resources.${index}.resources`;
-  const resources = readStrings(entry.resources, field) ?? [];
-  report(resources.length > 0, `${field} must not be empty.`);
-
-  resources.forEach((path, pathIndex) => {
-    const resourceField = `${field}.${pathIndex}`;
-    report(
-      !GLOB.test(path),
-      `${resourceField} must not contain a glob: ${path}`,
-    );
-    report(
-      CONCRETE_JS_ASSET.test(path),
-      `${resourceField} must expose only a concrete JS asset: ${path}`,
-    );
-    addReference(path, resourceField);
-  });
-});
-
-const verifyReference = async ({ field, value }) => {
-  const absolutePath = resolve(extensionDirectory, value);
-  const localPath = relative(extensionDirectory, absolutePath);
-  if (
-    isAbsolute(value) ||
-    /^[a-z][a-z0-9+.-]*:/iu.test(value) ||
-    localPath === '..' ||
-    localPath.startsWith('../') ||
-    localPath.startsWith('..\\') ||
-    isAbsolute(localPath)
-  ) {
-    return `${field} must stay within the extension directory: ${value}`;
-  }
-
-  try {
-    const file = await stat(absolutePath);
-    return file.isFile()
-      ? undefined
-      : `${field} does not reference a file: ${value}`;
-  } catch {
-    return `${field} references a missing file: ${value}`;
-  }
-};
-
-const referenceErrors = await Promise.all(references.map(verifyReference));
-errors.push(...referenceErrors.filter(Boolean));
 
 if (warnings.length > 0) {
   console.warn(

--- a/scripts/verify-manifest.test.mjs
+++ b/scripts/verify-manifest.test.mjs
@@ -45,7 +45,10 @@ const createExpectedManifest = (overrides = {}) => ({
   optional_permissions: [],
   optional_host_permissions: [],
   surfaces: {
-    action: false,
+    action: {
+      present: false,
+      default_popup: false,
+    },
     options_ui: false,
     background: false,
   },
@@ -136,7 +139,10 @@ test('validates a content-script and background product from its expectation obj
   const expectedManifest = createExpectedManifest({
     permissions: ['storage'],
     surfaces: {
-      action: false,
+      action: {
+        present: false,
+        default_popup: false,
+      },
       options_ui: false,
       background: true,
     },
@@ -175,8 +181,32 @@ test('validates a popup-and-options-only product from its expectation object', a
   const expectedManifest = createExpectedManifest({
     permissions: ['activeTab', 'scripting', 'storage'],
     surfaces: {
-      action: true,
+      action: {
+        present: true,
+        default_popup: true,
+      },
       options_ui: true,
+      background: false,
+    },
+  });
+
+  await expect(verify(manifest, expectedManifest)).resolves.toEqual({
+    errors: [],
+    warnings: [],
+  });
+});
+
+test('validates an action surface without a default popup', async () => {
+  const manifest = createManifest({
+    action: {},
+  });
+  const expectedManifest = createExpectedManifest({
+    surfaces: {
+      action: {
+        present: true,
+        default_popup: false,
+      },
+      options_ui: false,
       background: false,
     },
   });
@@ -231,7 +261,10 @@ test('rejects a declared surface whose built artifact is missing', async () => {
   });
   const expectedManifest = createExpectedManifest({
     surfaces: {
-      action: true,
+      action: {
+        present: true,
+        default_popup: true,
+      },
       options_ui: false,
       background: false,
     },

--- a/scripts/verify-manifest.test.mjs
+++ b/scripts/verify-manifest.test.mjs
@@ -1,0 +1,245 @@
+// @vitest-environment node
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { verifyManifest } from './verify-manifest-engine.mjs';
+
+const REQUIRED_CSP = "script-src 'self'; object-src 'self';";
+const CONCRETE_JS_ASSET = /^assets\/[^*?[\]{}]+\.js$/u;
+
+let extensionDirectory;
+
+beforeEach(async () => {
+  extensionDirectory = await mkdtemp(join(tmpdir(), 'verify-manifest-'));
+});
+
+afterEach(async () => {
+  await rm(extensionDirectory, { force: true, recursive: true });
+});
+
+const createFiles = async (paths) => {
+  await Promise.all(
+    paths.map(async (path) => {
+      const outputPath = join(extensionDirectory, path);
+      await mkdir(join(outputPath, '..'), { recursive: true });
+      await writeFile(outputPath, '');
+    }),
+  );
+};
+
+const createManifest = (overrides = {}) => ({
+  version: '1.0.0',
+  manifest_version: 3,
+  name: 'Test Extension',
+  content_security_policy: {
+    extension_pages: REQUIRED_CSP,
+  },
+  ...overrides,
+});
+
+const createExpectedManifest = (overrides = {}) => ({
+  permissions: [],
+  host_permissions: [],
+  optional_permissions: [],
+  optional_host_permissions: [],
+  surfaces: {
+    action: false,
+    options_ui: false,
+    background: false,
+  },
+  content_scripts: [],
+  web_accessible_resources: [],
+  ...overrides,
+});
+
+const verify = async (manifest, expectedManifest) =>
+  verifyManifest({
+    manifest,
+    packageJson: {
+      displayName: 'Test Extension',
+      version: '1.0.0',
+    },
+    expectedManifest,
+    extensionDirectory,
+  });
+
+test('validates a content-script-only product from its expectation object', async () => {
+  await createFiles(['assets/content-loader.js', 'assets/content.js']);
+  const matches = ['https://github.com/*'];
+  const manifest = createManifest({
+    content_scripts: [
+      {
+        js: ['assets/content-loader.js'],
+        matches,
+        run_at: 'document_idle',
+      },
+    ],
+    web_accessible_resources: [
+      {
+        matches,
+        resources: ['assets/content.js'],
+        use_dynamic_url: false,
+      },
+    ],
+  });
+  const expectedManifest = createExpectedManifest({
+    content_scripts: [{ matches, run_at: 'document_idle' }],
+    web_accessible_resources: [
+      {
+        matches,
+        extension_ids: [],
+        use_dynamic_url: false,
+        resources: {
+          required: [],
+          allowedPatterns: [CONCRETE_JS_ASSET],
+        },
+      },
+    ],
+  });
+
+  await expect(verify(manifest, expectedManifest)).resolves.toEqual({
+    errors: [],
+    warnings: [],
+  });
+});
+
+test('validates a content-script and background product from its expectation object', async () => {
+  await createFiles([
+    'service-worker-loader.js',
+    'assets/content-loader.js',
+    'assets/content.js',
+    'panel.html',
+  ]);
+  const matches = ['https://github.com/*'];
+  const manifest = createManifest({
+    permissions: ['storage'],
+    background: {
+      service_worker: 'service-worker-loader.js',
+      type: 'module',
+    },
+    content_scripts: [
+      {
+        js: ['assets/content-loader.js'],
+        matches,
+      },
+    ],
+    web_accessible_resources: [
+      {
+        matches,
+        resources: ['assets/content.js', 'panel.html'],
+        use_dynamic_url: false,
+      },
+    ],
+  });
+  const expectedManifest = createExpectedManifest({
+    permissions: ['storage'],
+    surfaces: {
+      action: false,
+      options_ui: false,
+      background: true,
+    },
+    content_scripts: [{ matches, run_at: 'document_idle' }],
+    web_accessible_resources: [
+      {
+        matches,
+        extension_ids: [],
+        use_dynamic_url: false,
+        resources: {
+          required: ['panel.html'],
+          allowedPatterns: [CONCRETE_JS_ASSET],
+        },
+      },
+    ],
+  });
+
+  await expect(verify(manifest, expectedManifest)).resolves.toEqual({
+    errors: [],
+    warnings: [],
+  });
+});
+
+test('validates a popup-and-options-only product from its expectation object', async () => {
+  await createFiles(['popup.html', 'options.html']);
+  const manifest = createManifest({
+    permissions: ['activeTab', 'scripting', 'storage'],
+    action: {
+      default_popup: 'popup.html',
+    },
+    options_ui: {
+      open_in_tab: true,
+      page: 'options.html',
+    },
+  });
+  const expectedManifest = createExpectedManifest({
+    permissions: ['activeTab', 'scripting', 'storage'],
+    surfaces: {
+      action: true,
+      options_ui: true,
+      background: false,
+    },
+  });
+
+  await expect(verify(manifest, expectedManifest)).resolves.toEqual({
+    errors: [],
+    warnings: [],
+  });
+});
+
+test('does not allow the expectation object to relax the CSP invariant', async () => {
+  const relaxedCsp = "script-src *; object-src 'self';";
+  const manifest = createManifest({
+    content_security_policy: {
+      extension_pages: relaxedCsp,
+    },
+  });
+  const expectedManifest = createExpectedManifest({
+    content_security_policy: {
+      extension_pages: relaxedCsp,
+    },
+  });
+
+  const { errors } = await verify(manifest, expectedManifest);
+
+  expect(errors).toContain(
+    `content_security_policy.extension_pages must equal ${JSON.stringify(REQUIRED_CSP)}; received ${JSON.stringify(relaxedCsp)}.`,
+  );
+});
+
+test('does not allow the expectation object to permit externally_connectable', async () => {
+  const externallyConnectable = {
+    matches: ['https://example.com/*'],
+  };
+  const manifest = createManifest({
+    externally_connectable: externallyConnectable,
+  });
+  const expectedManifest = createExpectedManifest({
+    externally_connectable: externallyConnectable,
+  });
+
+  const { errors } = await verify(manifest, expectedManifest);
+
+  expect(errors).toContain('externally_connectable must not be declared.');
+});
+
+test('rejects a declared surface whose built artifact is missing', async () => {
+  const manifest = createManifest({
+    action: {
+      default_popup: 'popup.html',
+    },
+  });
+  const expectedManifest = createExpectedManifest({
+    surfaces: {
+      action: true,
+      options_ui: false,
+      background: false,
+    },
+  });
+
+  const { errors } = await verify(manifest, expectedManifest);
+
+  expect(errors).toContain(
+    'action.default_popup references a missing file: popup.html',
+  );
+});


### PR DESCRIPTION
## 概要

- manifest の期待値を `scripts/expected-manifest.config.mjs` に分離
- `scripts/verify-manifest-engine.mjs` を構成非依存の検証エンジンとして追加
- content単独 / content+background / popup+options の3構成を期待値変更だけで検証できるテストを追加
- CSP と `externally_connectable` を設定ファイルから緩和できない不変条件として維持
- AGENTS.md の権限追加レシピと禁止事項を新構造へ更新

## 背景

派生プロダクトごとに `verify-manifest.mjs` 本体を改造すると、構成差分への追随時に参照整合性や権限ガードが欠落するため、製品固有の期待値と共通検証ロジックを分離しました。

## 影響

- 派生時の surface、content script、web accessible resources、権限変更は期待値ファイルの編集で表現可能
- `npm run verify` とCIジョブ構成は変更なし
- 新規依存関係なし

## 検証

- `npm run verify`
  - TypeScript: 成功
  - Oxlint: 成功
  - Vitest: 12ファイル / 41テスト成功
  - production build: 成功
  - manifest verification: 成功

Closes #124