### PR TITLE
[ISSUE 125] feat: E2E fixturesをsurface構成非依存化

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,5 +1,5 @@
 ---
-paths: ['**/*.test.{mjs,ts,tsx}']
+paths: ['**/*.test.{mjs,ts,tsx}', 'e2e/**/*.ts']
 ---
 
 Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
@@ -19,3 +19,16 @@ Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
   mocks in individual test files.
 - Because `installChromeFake` injects the global with `vi.stubGlobal`, call
   `vi.unstubAllGlobals()` in `afterEach`.
+- E2E tests run against the built extension with `npm run e2e`; use
+  `npm run verify:full` to build first and run the complete verification chain.
+- Configure E2E surface variants from the spec with
+  `test.use({ extensionOptions: { manifest: { remove, set }, contextOptions } })`.
+  Do not edit `e2e/fixtures.ts` for each derived product.
+- `extensionOptions.manifest.remove` deletes top-level manifest fields and
+  `extensionOptions.manifest.set` replaces them. Use `contextOptions` for
+  Playwright settings such as `timezoneId`.
+- Test content scripts at their production URL and intercept the response with
+  `extensionPage.route()`. Do not rewrite manifest match patterns or create a
+  local HTTP server solely for E2E.
+- Extension ID resolution is independent of service workers. Do not add a dummy
+  background worker to make Playwright fixtures start.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -26,7 +26,8 @@ Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
   Do not edit `e2e/fixtures.ts` for each derived product.
 - `extensionOptions.manifest.remove` deletes top-level manifest fields and
   `extensionOptions.manifest.set` replaces them. Use `contextOptions` for
-  Playwright settings such as `timezoneId`. The fixture rejects missing removal
+  Playwright settings such as `timezoneId`; use `loadTimeoutMs` to raise the
+  extension readiness timeout on slower CI. The fixture rejects missing removal
   targets, remove/set conflicts, and attempts to configure its reserved `key`.
 - Test content scripts at their production URL and intercept the response with
   `extensionPage.route()`. Do not rewrite manifest match patterns or create a
@@ -37,6 +38,9 @@ Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
   background worker to make Playwright fixtures start. The fixture probes the
   extension origin before exposing the context and reports invalid manifest
   patches as extension-load failures.
+- Pure E2E fixture logic lives in `e2e/*.test.ts` and runs in the fast Vitest
+  lane. Playwright is restricted to `e2e/*.spec.ts` so those tests are not run
+  twice.
 - `extensionOptions` and the persistent context are test-scoped so describe-level
   `test.use()` can model multiple surface variants in one spec. Each test that
   requests the context launches Chromium; group related assertions into one test.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -2,8 +2,9 @@
 paths: ['**/*.test.{mjs,ts,tsx}', 'e2e/**/*.ts']
 ---
 
-Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
-`// @vitest-environment node`).
+Vitest + jsdom (`src/**/*.test.{ts,tsx}`), Vitest + Node
+(`scripts/**/*.test.mjs` and `e2e/**/*.test.ts`, each with
+`// @vitest-environment node`), or Playwright (`e2e/**/*.spec.ts`).
 
 - Colocate tests as `*.test.ts(x)` next to the source file.
 - Components: `render`/`screen` from `@testing-library/react` (see `SampleComponent.test.tsx`).
@@ -38,9 +39,10 @@ Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
   background worker to make Playwright fixtures start. The fixture probes the
   extension origin before exposing the context and reports invalid manifest
   patches as extension-load failures.
-- Pure E2E fixture logic lives in `e2e/*.test.ts` and runs in the fast Vitest
-  lane. Playwright is restricted to `e2e/*.spec.ts` so those tests are not run
-  twice.
+- Pure E2E fixture logic lives in `e2e/*.test.ts`, selects the Node environment
+  with `// @vitest-environment node`, and runs in the fast Vitest lane.
+  Playwright is restricted to `e2e/*.spec.ts` so those tests are not run twice.
+  Import the reusable `ManifestPatch` type from `e2e/fixtures.ts`.
 - `extensionOptions` and the persistent context are test-scoped so describe-level
   `test.use()` can model multiple surface variants in one spec. Each test that
   requests the context launches Chromium; group related assertions into one test.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -26,9 +26,19 @@ Vitest + jsdom (`src/**/*.test.{ts,tsx}`) or Node (`scripts/**/*.test.mjs` with
   Do not edit `e2e/fixtures.ts` for each derived product.
 - `extensionOptions.manifest.remove` deletes top-level manifest fields and
   `extensionOptions.manifest.set` replaces them. Use `contextOptions` for
-  Playwright settings such as `timezoneId`.
+  Playwright settings such as `timezoneId`. The fixture rejects missing removal
+  targets, remove/set conflicts, and attempts to configure its reserved `key`.
 - Test content scripts at their production URL and intercept the response with
   `extensionPage.route()`. Do not rewrite manifest match patterns or create a
-  local HTTP server solely for E2E.
+  local HTTP server solely for E2E. When changing `content_scripts[].matches`,
+  update the production URL and host-permission values in the E2E spec so the
+  intercepted URL remains covered by the manifest.
 - Extension ID resolution is independent of service workers. Do not add a dummy
-  background worker to make Playwright fixtures start.
+  background worker to make Playwright fixtures start. The fixture probes the
+  extension origin before exposing the context and reports invalid manifest
+  patches as extension-load failures.
+- `extensionOptions` and the persistent context are test-scoped so describe-level
+  `test.use()` can model multiple surface variants in one spec. Each test that
+  requests the context launches Chromium; group related assertions into one test.
+  If startup cost becomes material, split variants into spec files or Playwright
+  projects and move their configuration to worker scope.

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -12,9 +12,11 @@ Checklist:
   `npm run verify:manifest` warns while `displayName` still has the template
   default.
 - **`manifest.config.ts`**: fill in `description` (currently empty), review
-  `permissions` (currently just `['background']`), and review
+  `permissions` (currently just `['storage']`), and review
   `content_scripts[].matches` — the template ships with a sample match on
-  `https://example.com/*`.
+  `https://example.com/*`. When changing that match, update the production URL
+  and host-permission values in `e2e/extension.spec.ts` so its intercepted page
+  is still covered.
 - **Delete or replace sample code**: `src/examples/` collects everything
   disposable — delete the whole directory in one shot, or replace pieces
   individually:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,8 +28,10 @@
   "overrides": [
     {
       // Keep runtime Chrome API access behind thin src/lib boundaries. Type-only
-      // references through the chrome namespace remain available throughout the project.
-      "files": ["src/**/*.{ts,tsx}"],
+      // references through the chrome namespace remain available throughout the
+      // project; E2E callbacks that execute inside an extension page need an
+      // explicit, reasoned disable at the call site.
+      "files": ["src/**/*.{ts,tsx}", "e2e/**/*.{ts,tsx}"],
       "excludeFiles": ["src/lib/**/*.{ts,tsx}"],
       "rules": {
         "no-restricted-globals": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ README's "Architecture" section for the full dependency-direction rules.
 | `npm run verify:full` | `verify` then `npm run e2e` | full contract; requires installed Chromium |
 | `npm run e2e` | Run Playwright Chromium smoke tests | requires a prior build and installed Chromium |
 | `npm run check-type` | `tsc --noEmit` | |
-| `npm test` | Run Vitest | src tests use jsdom; script tests use Node |
+| `npm test` | Run Vitest | src tests use jsdom; script and e2e helper tests use Node |
 | `npm run lint` | `oxlint` (check-only) | no file mutation; pre-commit runs the staged-only equivalent via lint-staged |
 | `npm run format` | `prettier --write` | rewrites files on disk; pre-commit runs the staged-only equivalent via lint-staged |
 | `npm run zip` | Alias for `npm run package` | |
@@ -119,7 +119,7 @@ Do not make these without explicit owner sign-off. Most are enforced by
 
 - Named exports only, no default exports — except `*.config.ts` (`vite.config.ts`, `manifest.config.ts`, `playwright.config.ts`, `vitest.config.ts`), which must keep `export default` because Vite/CRXJS/Playwright/Vitest require it to load the config.
 - Components are arrow functions.
-- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or `*.test.mjs` next to Node scripts; Playwright smoke tests live under `e2e/` as `*.spec.ts`.
+- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or `*.test.mjs` next to Node scripts; E2E helper unit tests live under `e2e/` as `*.test.ts` with the Node environment pragma, while Playwright smoke tests use `*.spec.ts`.
 - Hooks return tuples `as const` (state, action).
 - Everything else (formatting, quote style, etc.) is enforced by Oxlint/Prettier/tsc — run them, don't hand-check. Import order is not lint-enforced (no Oxlint equivalent to the old `import/order`); keep imports reasonably grouped by convention.
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,10 @@ The template separates reusable infrastructure (`src/lib/`) from sample code:
    has the template default.
 4. Adjust or remove the content script `matches` (`https://example.com/*`) in
    `manifest.config.ts` — and mirror the change in
-   `scripts/expected-manifest.config.mjs` (see below). The same expectation file
-   declares which extension surfaces and web-accessible resources must be present.
+   `scripts/expected-manifest.config.mjs` (see below), plus the production URL
+   and host-permission constants in `e2e/extension.spec.ts`. The same expectation
+   file declares which extension surfaces and web-accessible resources must be
+   present.
 
 `.claude/skills/adapt-template/SKILL.md` contains the full checklist.
 

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -1,39 +1,143 @@
+import type { Page } from '@playwright/test';
+
 import { expect, test } from './fixtures';
 
-const popupUrl = (extensionId: string): string =>
-  `chrome-extension://${extensionId}/popup.html`;
+const PRODUCTION_PAGE_URL = 'https://example.com/e2e-fixture';
+const EXTENSION_ORIGIN = 'chrome-extension://';
+const E2E_HOST_PERMISSION = 'https://example.com/*';
 
-test('popup page renders its primary UI', async ({
-  extensionId,
-  extensionPage,
-}) => {
-  await extensionPage.goto(popupUrl(extensionId));
+const extensionPageUrl = (extensionId: string, path: string): string =>
+  `${EXTENSION_ORIGIN}${extensionId}/${path}`;
 
-  await expect(
-    extensionPage.getByRole('heading', { name: 'popup' }),
-  ).toBeVisible();
-  await expect(
-    extensionPage.getByRole('button', { name: 'send message' }),
-  ).toBeVisible();
+const routeProductionPage = async (page: Page): Promise<void> => {
+  await page.route(PRODUCTION_PAGE_URL, async (route) => {
+    await route.fulfill({
+      body: '<!doctype html><html><body><main>E2E fixture page</main></body></html>',
+      contentType: 'text/html; charset=utf-8',
+      status: 200,
+    });
+  });
+};
+
+test.describe('default sample configuration', () => {
+  test('popup exchanges a typed message with the background', async ({
+    extensionId,
+    extensionPage,
+  }) => {
+    await extensionPage.goto(extensionPageUrl(extensionId, 'popup.html'));
+    await extensionPage.getByRole('button', { name: 'send message' }).click();
+
+    await expect(extensionPage.getByText('Hello, popup!')).toBeVisible();
+  });
+
+  test('content script is injected at its production URL', async ({
+    extensionPage,
+  }) => {
+    await routeProductionPage(extensionPage);
+    await extensionPage.goto(PRODUCTION_PAGE_URL);
+
+    await expect(
+      extensionPage.getByRole('heading', { name: 'content_script sample' }),
+    ).toBeVisible();
+  });
 });
 
-test('popup exchanges a typed message with the background', async ({
-  extensionId,
-  extensionPage,
-}) => {
-  await extensionPage.goto(popupUrl(extensionId));
-  await extensionPage.getByRole('button', { name: 'send message' }).click();
+test.describe('content-only configuration', () => {
+  test.use({
+    extensionOptions: {
+      manifest: {
+        remove: ['action', 'background', 'options_ui'],
+      },
+    },
+  });
 
-  await expect(extensionPage.getByText('Hello, popup!')).toBeVisible();
+  test('loads without a background and injects the content script', async ({
+    extensionContext,
+    extensionPage,
+  }) => {
+    await routeProductionPage(extensionPage);
+    await extensionPage.goto(PRODUCTION_PAGE_URL);
+
+    await expect(
+      extensionPage.getByRole('heading', { name: 'content_script sample' }),
+    ).toBeVisible();
+    expect(
+      extensionContext
+        .serviceWorkers()
+        .filter((worker) => worker.url().startsWith(EXTENSION_ORIGIN)),
+    ).toHaveLength(0);
+  });
 });
 
-test('content script is injected into a locally served page', async ({
-  extensionPage,
-  testPageUrl,
-}) => {
-  await extensionPage.goto(testPageUrl);
+test.describe('content and background configuration', () => {
+  test.use({
+    extensionOptions: {
+      contextOptions: {
+        timezoneId: 'UTC',
+      },
+      manifest: {
+        remove: ['action', 'options_ui'],
+      },
+    },
+  });
 
-  await expect(
-    extensionPage.getByRole('heading', { name: 'content_script sample' }),
-  ).toBeVisible();
+  test('loads both declared surfaces', async ({
+    extensionContext,
+    extensionId,
+    extensionPage,
+  }) => {
+    await routeProductionPage(extensionPage);
+    await extensionPage.goto(PRODUCTION_PAGE_URL);
+
+    await expect(
+      extensionPage.getByRole('heading', { name: 'content_script sample' }),
+    ).toBeVisible();
+
+    let serviceWorker = extensionContext
+      .serviceWorkers()
+      .find((worker) => worker.url().startsWith(EXTENSION_ORIGIN));
+    serviceWorker ??= await extensionContext.waitForEvent('serviceworker', {
+      predicate: (worker) => worker.url().startsWith(EXTENSION_ORIGIN),
+    });
+    expect(new URL(serviceWorker.url()).host).toBe(extensionId);
+  });
+});
+
+test.describe('popup and options configuration', () => {
+  test.use({
+    extensionOptions: {
+      manifest: {
+        remove: ['background', 'content_scripts'],
+        set: {
+          host_permissions: [E2E_HOST_PERMISSION],
+        },
+      },
+    },
+  });
+
+  test('resolves the extension ID without a background and renders both pages', async ({
+    extensionContext,
+    extensionId,
+    extensionPage,
+  }) => {
+    await extensionPage.goto(extensionPageUrl(extensionId, 'popup.html'));
+    await expect(
+      extensionPage.getByRole('heading', { name: 'popup' }),
+    ).toBeVisible();
+
+    await extensionPage.goto(extensionPageUrl(extensionId, 'options.html'));
+    await expect(
+      extensionPage.getByRole('heading', { name: 'Options' }),
+    ).toBeVisible();
+    expect(
+      await extensionPage.evaluate(() => chrome.runtime.getManifest()),
+    ).toMatchObject({
+      host_permissions: [E2E_HOST_PERMISSION],
+    });
+    expect(
+      extensionContext
+        .serviceWorkers()
+        .filter((worker) => worker.url().startsWith(EXTENSION_ORIGIN)),
+    ).toHaveLength(0);
+  });
 });

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { expect, test } from './fixtures';
+import { E2E_EXTENSION_ID, expect, test } from './fixtures';
 
 const PRODUCTION_PAGE_URL = 'https://example.com/e2e-fixture';
 const EXTENSION_ORIGIN = 'chrome-extension://';
@@ -44,11 +44,14 @@ test.describe('extension ID fixture override', () => {
   });
 
   test('keeps readiness tied to the manifest key', async ({
-    extensionContext,
     extensionId,
+    extensionPage,
   }) => {
     expect(extensionId).toBe(OVERRIDDEN_EXTENSION_ID);
-    expect(extensionContext.browser()?.isConnected()).toBe(true);
+    const response = await extensionPage.goto(
+      extensionPageUrl(E2E_EXTENSION_ID, 'manifest.json'),
+    );
+    expect(response?.ok()).toBe(true);
   });
 });
 

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { expect, test } from './fixtures';
+import { createExtensionId, expect, patchManifest, test } from './fixtures';
 
 const PRODUCTION_PAGE_URL = 'https://example.com/e2e-fixture';
 const EXTENSION_ORIGIN = 'chrome-extension://';
@@ -19,8 +19,84 @@ const routeProductionPage = async (page: Page): Promise<void> => {
   });
 };
 
+test.describe('manifest patch configuration', () => {
+  test('applies explicit removals and replacements', () => {
+    expect(
+      patchManifest(
+        {
+          action: {},
+          background: {},
+        },
+        {
+          remove: ['background'],
+          set: {
+            host_permissions: [E2E_HOST_PERMISSION],
+          },
+        },
+      ),
+    ).toEqual({
+      action: {},
+      host_permissions: [E2E_HOST_PERMISSION],
+    });
+  });
+
+  test('rejects a missing removal target', () => {
+    expect(() =>
+      patchManifest(
+        {
+          background: {},
+        },
+        {
+          remove: ['options_ui'],
+        },
+      ),
+    ).toThrow('Manifest has no top-level field "options_ui" to remove.');
+  });
+
+  test('rejects fields configured by both remove and set', () => {
+    expect(() =>
+      patchManifest(
+        {
+          background: {},
+        },
+        {
+          remove: ['background'],
+          set: {
+            background: {
+              service_worker: 'replacement.js',
+            },
+          },
+        },
+      ),
+    ).toThrow(
+      'Manifest field "background" cannot be configured by both remove and set.',
+    );
+  });
+
+  test('rejects overriding the fixture-owned extension key', () => {
+    expect(() =>
+      patchManifest(
+        {
+          name: 'extension',
+        },
+        {
+          set: {
+            key: 'another-key',
+          },
+        },
+      ),
+    ).toThrow('Manifest field "key" is reserved by the E2E fixture.');
+  });
+
+  test('derives the Chrome extension ID from a manifest public key', () => {
+    expect(createExtensionId('dGVzdC1rZXk=')).toBe(
+      'gckpihaehgepkpiokicpmgbmojmemdja',
+    );
+  });
+});
+
 test.describe('default sample configuration', () => {
-  test('popup exchanges a typed message with the background', async ({
+  test('supports popup messaging and production-URL content injection', async ({
     extensionId,
     extensionPage,
   }) => {
@@ -28,11 +104,6 @@ test.describe('default sample configuration', () => {
     await extensionPage.getByRole('button', { name: 'send message' }).click();
 
     await expect(extensionPage.getByText('Hello, popup!')).toBeVisible();
-  });
-
-  test('content script is injected at its production URL', async ({
-    extensionPage,
-  }) => {
     await routeProductionPage(extensionPage);
     await extensionPage.goto(PRODUCTION_PAGE_URL);
 
@@ -130,7 +201,10 @@ test.describe('popup and options configuration', () => {
       extensionPage.getByRole('heading', { name: 'Options' }),
     ).toBeVisible();
     expect(
-      await extensionPage.evaluate(() => chrome.runtime.getManifest()),
+      await extensionPage.evaluate(() => {
+        // oxlint-disable-next-line no-restricted-globals -- This callback runs inside the extension page and verifies its effective manifest.
+        return chrome.runtime.getManifest();
+      }),
     ).toMatchObject({
       host_permissions: [E2E_HOST_PERMISSION],
     });

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { createExtensionId, expect, patchManifest, test } from './fixtures';
+import { expect, test } from './fixtures';
 
 const PRODUCTION_PAGE_URL = 'https://example.com/e2e-fixture';
 const EXTENSION_ORIGIN = 'chrome-extension://';
@@ -18,82 +18,6 @@ const routeProductionPage = async (page: Page): Promise<void> => {
     });
   });
 };
-
-test.describe('manifest patch configuration', () => {
-  test('applies explicit removals and replacements', () => {
-    expect(
-      patchManifest(
-        {
-          action: {},
-          background: {},
-        },
-        {
-          remove: ['background'],
-          set: {
-            host_permissions: [E2E_HOST_PERMISSION],
-          },
-        },
-      ),
-    ).toEqual({
-      action: {},
-      host_permissions: [E2E_HOST_PERMISSION],
-    });
-  });
-
-  test('rejects a missing removal target', () => {
-    expect(() =>
-      patchManifest(
-        {
-          background: {},
-        },
-        {
-          remove: ['options_ui'],
-        },
-      ),
-    ).toThrow('Manifest has no top-level field "options_ui" to remove.');
-  });
-
-  test('rejects fields configured by both remove and set', () => {
-    expect(() =>
-      patchManifest(
-        {
-          background: {},
-        },
-        {
-          remove: ['background'],
-          set: {
-            background: {
-              service_worker: 'replacement.js',
-            },
-          },
-        },
-      ),
-    ).toThrow(
-      'Manifest field "background" cannot be configured by both remove and set.',
-    );
-  });
-
-  test('rejects overriding the fixture-owned extension key', () => {
-    expect(() =>
-      patchManifest(
-        {
-          name: 'extension',
-        },
-        {
-          set: {
-            key: 'another-key',
-          },
-        },
-      ),
-    ).toThrow('Manifest field "key" is reserved by the E2E fixture.');
-  });
-
-  test('derives the Chrome extension ID from a manifest public key', () => {
-    expect(createExtensionId('dGVzdC1rZXk=')).toBe(
-      'gckpihaehgepkpiokicpmgbmojmemdja',
-    );
-  });
-});
 
 test.describe('default sample configuration', () => {
   test('supports popup messaging and production-URL content injection', async ({

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from './fixtures';
 const PRODUCTION_PAGE_URL = 'https://example.com/e2e-fixture';
 const EXTENSION_ORIGIN = 'chrome-extension://';
 const E2E_HOST_PERMISSION = 'https://example.com/*';
+const OVERRIDDEN_EXTENSION_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 const extensionPageUrl = (extensionId: string, path: string): string =>
   `${EXTENSION_ORIGIN}${extensionId}/${path}`;
@@ -34,6 +35,20 @@ test.describe('default sample configuration', () => {
     await expect(
       extensionPage.getByRole('heading', { name: 'content_script sample' }),
     ).toBeVisible();
+  });
+});
+
+test.describe('extension ID fixture override', () => {
+  test.use({
+    extensionId: OVERRIDDEN_EXTENSION_ID,
+  });
+
+  test('keeps readiness tied to the manifest key', async ({
+    extensionContext,
+    extensionId,
+  }) => {
+    expect(extensionId).toBe(OVERRIDDEN_EXTENSION_ID);
+    expect(extensionContext.browser()?.isConnected()).toBe(true);
   });
 });
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from 'node:http';
+import { createHash } from 'node:crypto';
 import { access, cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -11,40 +11,71 @@ import {
   type Page,
 } from '@playwright/test';
 
-const PRODUCTION_CONTENT_MATCH = 'https://example.com/*';
-const E2E_CONTENT_MATCH = 'http://127.0.0.1/*';
+const E2E_EXTENSION_KEY =
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnlJy17+s4cRAMFlCbRTU6FAexIDBc+qXqUYu+aYKe6EXMFSFGyzggYn27xShGmpYYgC4lqxt90NRqmc+Vn8rMifwWHVuIdJ+MlpJf3niCXZWvIvaFqsvItXdrxTLFU9BZQYNZOmmgopqD3o6GgF2EqCZE5jjMfAw3iozBU5UT1driPC0pNcxP16GmJF0e6kcOIDZO2JTVyzSlfKlzs6NHj8yFu/8/MEIpW1/ZilcHW8kCPxAMpF66/+p9pJD8ztZ9xmuZaKStmD1oyucYeafbVekBbIhyTqaiZDsdda4urCifMT/lswtcmjPgV9XcMqkBF0Qn7rQEhw5xpkivLR8UwIDAQAB';
+
+type PersistentContextOptions = NonNullable<
+  Parameters<typeof chromium.launchPersistentContext>[1]
+>;
+
+export type ManifestPatch = {
+  remove?: readonly string[];
+  set?: Readonly<Record<string, unknown>>;
+};
+
+export type ExtensionOptions = {
+  contextOptions?: Omit<
+    PersistentContextOptions,
+    'args' | 'channel' | 'headless'
+  >;
+  manifest?: ManifestPatch;
+};
 
 type TestFixtures = {
+  extensionContext: BrowserContext;
+  extensionId: string;
+  extensionOptions: ExtensionOptions;
   extensionPage: Page;
 };
 
-type WorkerFixtures = {
-  extensionContext: BrowserContext;
-  extensionId: string;
-  testPageUrl: string;
-};
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const replaceContentMatches = (entries: unknown): number => {
-  if (!Array.isArray(entries)) return 0;
-
-  let replacementCount = 0;
-  for (const entry of entries) {
-    if (!isRecord(entry) || !Array.isArray(entry.matches)) continue;
-
-    entry.matches = entry.matches.map((match) => {
-      if (match !== PRODUCTION_CONTENT_MATCH) return match;
-      replacementCount += 1;
-      return E2E_CONTENT_MATCH;
-    });
+export const patchManifest = (
+  manifest: unknown,
+  patch: ManifestPatch = {},
+): Record<string, unknown> => {
+  if (!isRecord(manifest)) {
+    throw new Error('Built extension manifest must be an object.');
   }
 
-  return replacementCount;
+  const patchedManifest = { ...manifest };
+  for (const field of patch.remove ?? []) {
+    delete patchedManifest[field];
+  }
+
+  return {
+    ...patchedManifest,
+    ...patch.set,
+  };
 };
 
-const prepareExtension = async (): Promise<{
+const createExtensionId = (manifestKey: string): string => {
+  const hashPrefix = createHash('sha256')
+    .update(Buffer.from(manifestKey, 'base64'))
+    .digest('hex')
+    .slice(0, 32);
+
+  return hashPrefix.replace(/[0-9a-f]/gu, (digit) =>
+    String.fromCharCode('a'.charCodeAt(0) + Number.parseInt(digit, 16)),
+  );
+};
+
+const E2E_EXTENSION_ID = createExtensionId(E2E_EXTENSION_KEY);
+
+const prepareExtension = async (
+  manifestPatch: ManifestPatch | undefined,
+): Promise<{
   extensionPath: string;
   temporaryDirectory: string;
 }> => {
@@ -69,37 +100,12 @@ const prepareExtension = async (): Promise<{
     const parsedManifest: unknown = JSON.parse(
       await readFile(manifestPath, 'utf8'),
     );
-    if (!isRecord(parsedManifest)) {
-      throw new Error('Built extension manifest must be an object.');
-    }
+    const patchedManifest = patchManifest(parsedManifest, manifestPatch);
+    patchedManifest.key = E2E_EXTENSION_KEY;
 
-    if (
-      !isRecord(parsedManifest.background) ||
-      typeof parsedManifest.background.service_worker !== 'string'
-    ) {
-      throw new Error('Built extension has no background service worker.');
-    }
-
-    const contentScriptMatches = replaceContentMatches(
-      parsedManifest.content_scripts,
-    );
-    if (contentScriptMatches === 0) {
-      throw new Error(
-        `Built extension has no content script matching ${PRODUCTION_CONTENT_MATCH}.`,
-      );
-    }
-
-    const webAccessibleResourceMatches = replaceContentMatches(
-      parsedManifest.web_accessible_resources,
-    );
-    if (webAccessibleResourceMatches === 0) {
-      throw new Error(
-        `Built extension has no web_accessible_resources matching ${PRODUCTION_CONTENT_MATCH}.`,
-      );
-    }
     await writeFile(
       manifestPath,
-      `${JSON.stringify(parsedManifest, null, 2)}\n`,
+      `${JSON.stringify(patchedManifest, null, 2)}\n`,
       'utf8',
     );
 
@@ -110,92 +116,41 @@ const prepareExtension = async (): Promise<{
   }
 };
 
-const closeServer = (server: Server): Promise<void> =>
-  new Promise((resolvePromise, rejectPromise) => {
-    server.close((error) => {
-      if (error) rejectPromise(error);
-      else resolvePromise();
-    });
-    server.closeAllConnections();
-  });
+export const test = base.extend<TestFixtures>({
+  extensionOptions: [{}, { option: true }],
 
-export const test = base.extend<TestFixtures, WorkerFixtures>({
-  extensionContext: [
+  extensionContext: async ({ extensionOptions }, provide) => {
+    const { extensionPath, temporaryDirectory } = await prepareExtension(
+      extensionOptions.manifest,
+    );
+    let context: BrowserContext | undefined;
+
+    try {
+      context = await chromium.launchPersistentContext(
+        join(temporaryDirectory, 'user-data'),
+        {
+          ...extensionOptions.contextOptions,
+          channel: 'chromium',
+          headless: true,
+          args: [
+            `--disable-extensions-except=${extensionPath}`,
+            `--load-extension=${extensionPath}`,
+          ],
+        },
+      );
+      await provide(context);
+    } finally {
+      await context?.close();
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  },
+
+  extensionId:
     // Playwright requires the fixture dependency argument to use object destructuring.
     // oxlint-disable-next-line no-empty-pattern
     async ({}, provide) => {
-      const { extensionPath, temporaryDirectory } = await prepareExtension();
-      let context: BrowserContext | undefined;
-
-      try {
-        context = await chromium.launchPersistentContext(
-          join(temporaryDirectory, 'user-data'),
-          {
-            channel: 'chromium',
-            headless: true,
-            args: [
-              `--disable-extensions-except=${extensionPath}`,
-              `--load-extension=${extensionPath}`,
-            ],
-          },
-        );
-        await provide(context);
-      } finally {
-        await context?.close();
-        await rm(temporaryDirectory, { recursive: true, force: true });
-      }
+      await provide(E2E_EXTENSION_ID);
     },
-    { scope: 'worker' },
-  ],
-
-  extensionId: [
-    async ({ extensionContext }, provide) => {
-      let serviceWorker = extensionContext
-        .serviceWorkers()
-        .find((worker) => worker.url().startsWith('chrome-extension://'));
-
-      serviceWorker ??= await extensionContext.waitForEvent('serviceworker', {
-        predicate: (worker) => worker.url().startsWith('chrome-extension://'),
-      });
-
-      await provide(new URL(serviceWorker.url()).host);
-    },
-    { scope: 'worker' },
-  ],
-
-  testPageUrl: [
-    // Playwright requires the fixture dependency argument to use object destructuring.
-    // oxlint-disable-next-line no-empty-pattern
-    async ({}, provide) => {
-      const server = createServer((_request, response) => {
-        response.writeHead(200, {
-          Connection: 'close',
-          'Content-Type': 'text/html; charset=utf-8',
-        });
-        response.end(
-          '<!doctype html><html><body><main>E2E fixture page</main></body></html>',
-        );
-      });
-
-      await new Promise<void>((resolvePromise, rejectPromise) => {
-        server.once('error', rejectPromise);
-        server.listen(0, '127.0.0.1', resolvePromise);
-      });
-
-      const address = server.address();
-      if (!address || typeof address === 'string') {
-        await closeServer(server);
-        throw new Error('Failed to resolve the local E2E server address.');
-      }
-
-      try {
-        await provide(`http://127.0.0.1:${address.port}/`);
-      } finally {
-        await closeServer(server);
-      }
-    },
-    { scope: 'worker' },
-  ],
 
   extensionPage: async ({ extensionContext }, provide) => {
     const page = await extensionContext.newPage();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { access, cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -11,27 +10,28 @@ import {
   type Page,
 } from '@playwright/test';
 
+import {
+  createExtensionId,
+  patchManifest,
+  type ManifestPatch,
+} from './manifest';
+
 // Test-only RSA public key generated for this fixture. Chrome uses it to assign
 // a stable unpacked-extension ID; it is public material and needs no secret key.
 const E2E_EXTENSION_KEY =
   'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnlJy17+s4cRAMFlCbRTU6FAexIDBc+qXqUYu+aYKe6EXMFSFGyzggYn27xShGmpYYgC4lqxt90NRqmc+Vn8rMifwWHVuIdJ+MlpJf3niCXZWvIvaFqsvItXdrxTLFU9BZQYNZOmmgopqD3o6GgF2EqCZE5jjMfAw3iozBU5UT1driPC0pNcxP16GmJF0e6kcOIDZO2JTVyzSlfKlzs6NHj8yFu/8/MEIpW1/ZilcHW8kCPxAMpF66/+p9pJD8ztZ9xmuZaKStmD1oyucYeafbVekBbIhyTqaiZDsdda4urCifMT/lswtcmjPgV9XcMqkBF0Qn7rQEhw5xpkivLR8UwIDAQAB';
-const E2E_RESERVED_MANIFEST_FIELD = 'key';
-const EXTENSION_LOAD_TIMEOUT_MS = 5_000;
+const DEFAULT_EXTENSION_LOAD_TIMEOUT_MS = 5_000;
 
 type PersistentContextOptions = NonNullable<
   Parameters<typeof chromium.launchPersistentContext>[1]
 >;
-
-export type ManifestPatch = {
-  remove?: readonly string[];
-  set?: Readonly<Record<string, unknown>>;
-};
 
 export type ExtensionOptions = {
   contextOptions?: Omit<
     PersistentContextOptions,
     'args' | 'channel' | 'headless'
   >;
+  loadTimeoutMs?: number;
   manifest?: ManifestPatch;
 };
 
@@ -42,73 +42,12 @@ type TestFixtures = {
   extensionPage: Page;
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-export const patchManifest = (
-  manifest: unknown,
-  patch: ManifestPatch = {},
-): Record<string, unknown> => {
-  if (!isRecord(manifest)) {
-    throw new Error('Built extension manifest must be an object.');
-  }
-
-  const removeFields = patch.remove ?? [];
-  const setFields = new Set(Object.keys(patch.set ?? {}));
-  if (
-    removeFields.includes(E2E_RESERVED_MANIFEST_FIELD) ||
-    setFields.has(E2E_RESERVED_MANIFEST_FIELD)
-  ) {
-    throw new Error(
-      `Manifest field "${E2E_RESERVED_MANIFEST_FIELD}" is reserved by the E2E fixture.`,
-    );
-  }
-
-  const patchedManifest = { ...manifest };
-  const removedFields = new Set<string>();
-  for (const field of removeFields) {
-    if (removedFields.has(field)) {
-      throw new Error(
-        `Manifest field "${field}" is listed more than once in remove.`,
-      );
-    }
-    if (setFields.has(field)) {
-      throw new Error(
-        `Manifest field "${field}" cannot be configured by both remove and set.`,
-      );
-    }
-    if (!Object.hasOwn(patchedManifest, field)) {
-      throw new Error(`Manifest has no top-level field "${field}" to remove.`);
-    }
-
-    removedFields.add(field);
-    delete patchedManifest[field];
-  }
-
-  return {
-    ...patchedManifest,
-    ...patch.set,
-  };
-};
-
-// Chrome hashes the public key, takes the first 16 bytes, then maps each hex
-// digit 0-f to a-p to form the 32-character extension ID.
-export const createExtensionId = (manifestKey: string): string => {
-  const hashPrefix = createHash('sha256')
-    .update(Buffer.from(manifestKey, 'base64'))
-    .digest('hex')
-    .slice(0, 32);
-
-  return hashPrefix.replace(/[0-9a-f]/gu, (digit) =>
-    String.fromCharCode('a'.charCodeAt(0) + Number.parseInt(digit, 16)),
-  );
-};
-
 const E2E_EXTENSION_ID = createExtensionId(E2E_EXTENSION_KEY);
 
 const verifyExtensionLoaded = async (
   context: BrowserContext,
   extensionId: string,
+  timeout: number,
 ): Promise<void> => {
   const probePage = await context.newPage();
 
@@ -120,7 +59,7 @@ const verifyExtensionLoaded = async (
       expect(response?.ok()).toBe(true);
     }).toPass({
       intervals: [100, 250, 500],
-      timeout: EXTENSION_LOAD_TIMEOUT_MS,
+      timeout,
     });
   } catch (cause: unknown) {
     throw new Error(
@@ -197,7 +136,11 @@ export const test = base.extend<TestFixtures>({
           ],
         },
       );
-      await verifyExtensionLoaded(context, extensionId);
+      await verifyExtensionLoaded(
+        context,
+        extensionId,
+        extensionOptions.loadTimeoutMs ?? DEFAULT_EXTENSION_LOAD_TIMEOUT_MS,
+      );
       await provide(context);
     } finally {
       await context?.close();
@@ -205,7 +148,7 @@ export const test = base.extend<TestFixtures>({
     }
   },
 
-  extensionId: [E2E_EXTENSION_ID, { option: true }],
+  extensionId: E2E_EXTENSION_ID,
 
   extensionPage: async ({ extensionContext }, provide) => {
     const page = await extensionContext.newPage();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -44,7 +44,7 @@ type TestFixtures = {
   extensionPage: Page;
 };
 
-const E2E_EXTENSION_ID = createExtensionId(E2E_EXTENSION_KEY);
+export const E2E_EXTENSION_ID = createExtensionId(E2E_EXTENSION_KEY);
 
 const verifyExtensionLoaded = async (
   context: BrowserContext,

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -16,6 +16,8 @@ import {
   type ManifestPatch,
 } from './manifest';
 
+export type { ManifestPatch } from './manifest';
+
 // Test-only RSA public key generated for this fixture. Chrome uses it to assign
 // a stable unpacked-extension ID; it is public material and needs no secret key.
 const E2E_EXTENSION_KEY =
@@ -117,7 +119,7 @@ const prepareExtension = async (
 export const test = base.extend<TestFixtures>({
   extensionOptions: [{}, { option: true }],
 
-  extensionContext: async ({ extensionId, extensionOptions }, provide) => {
+  extensionContext: async ({ extensionOptions }, provide) => {
     const { extensionPath, temporaryDirectory } = await prepareExtension(
       extensionOptions.manifest,
     );
@@ -138,7 +140,9 @@ export const test = base.extend<TestFixtures>({
       );
       await verifyExtensionLoaded(
         context,
-        extensionId,
+        // Readiness follows the fixture-owned manifest key even if a test
+        // overrides the separately exposed extensionId value.
+        E2E_EXTENSION_ID,
         extensionOptions.loadTimeoutMs ?? DEFAULT_EXTENSION_LOAD_TIMEOUT_MS,
       );
       await provide(context);

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -11,8 +11,12 @@ import {
   type Page,
 } from '@playwright/test';
 
+// Test-only RSA public key generated for this fixture. Chrome uses it to assign
+// a stable unpacked-extension ID; it is public material and needs no secret key.
 const E2E_EXTENSION_KEY =
   'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnlJy17+s4cRAMFlCbRTU6FAexIDBc+qXqUYu+aYKe6EXMFSFGyzggYn27xShGmpYYgC4lqxt90NRqmc+Vn8rMifwWHVuIdJ+MlpJf3niCXZWvIvaFqsvItXdrxTLFU9BZQYNZOmmgopqD3o6GgF2EqCZE5jjMfAw3iozBU5UT1driPC0pNcxP16GmJF0e6kcOIDZO2JTVyzSlfKlzs6NHj8yFu/8/MEIpW1/ZilcHW8kCPxAMpF66/+p9pJD8ztZ9xmuZaKStmD1oyucYeafbVekBbIhyTqaiZDsdda4urCifMT/lswtcmjPgV9XcMqkBF0Qn7rQEhw5xpkivLR8UwIDAQAB';
+const E2E_RESERVED_MANIFEST_FIELD = 'key';
+const EXTENSION_LOAD_TIMEOUT_MS = 5_000;
 
 type PersistentContextOptions = NonNullable<
   Parameters<typeof chromium.launchPersistentContext>[1]
@@ -49,8 +53,35 @@ export const patchManifest = (
     throw new Error('Built extension manifest must be an object.');
   }
 
+  const removeFields = patch.remove ?? [];
+  const setFields = new Set(Object.keys(patch.set ?? {}));
+  if (
+    removeFields.includes(E2E_RESERVED_MANIFEST_FIELD) ||
+    setFields.has(E2E_RESERVED_MANIFEST_FIELD)
+  ) {
+    throw new Error(
+      `Manifest field "${E2E_RESERVED_MANIFEST_FIELD}" is reserved by the E2E fixture.`,
+    );
+  }
+
   const patchedManifest = { ...manifest };
-  for (const field of patch.remove ?? []) {
+  const removedFields = new Set<string>();
+  for (const field of removeFields) {
+    if (removedFields.has(field)) {
+      throw new Error(
+        `Manifest field "${field}" is listed more than once in remove.`,
+      );
+    }
+    if (setFields.has(field)) {
+      throw new Error(
+        `Manifest field "${field}" cannot be configured by both remove and set.`,
+      );
+    }
+    if (!Object.hasOwn(patchedManifest, field)) {
+      throw new Error(`Manifest has no top-level field "${field}" to remove.`);
+    }
+
+    removedFields.add(field);
     delete patchedManifest[field];
   }
 
@@ -60,7 +91,9 @@ export const patchManifest = (
   };
 };
 
-const createExtensionId = (manifestKey: string): string => {
+// Chrome hashes the public key, takes the first 16 bytes, then maps each hex
+// digit 0-f to a-p to form the 32-character extension ID.
+export const createExtensionId = (manifestKey: string): string => {
   const hashPrefix = createHash('sha256')
     .update(Buffer.from(manifestKey, 'base64'))
     .digest('hex')
@@ -72,6 +105,32 @@ const createExtensionId = (manifestKey: string): string => {
 };
 
 const E2E_EXTENSION_ID = createExtensionId(E2E_EXTENSION_KEY);
+
+const verifyExtensionLoaded = async (
+  context: BrowserContext,
+  extensionId: string,
+): Promise<void> => {
+  const probePage = await context.newPage();
+
+  try {
+    await expect(async () => {
+      const response = await probePage.goto(
+        `chrome-extension://${extensionId}/manifest.json`,
+      );
+      expect(response?.ok()).toBe(true);
+    }).toPass({
+      intervals: [100, 250, 500],
+      timeout: EXTENSION_LOAD_TIMEOUT_MS,
+    });
+  } catch (cause: unknown) {
+    throw new Error(
+      `Extension failed to load (id=${extensionId}). Check extensionOptions.manifest.`,
+      { cause },
+    );
+  } finally {
+    await probePage.close();
+  }
+};
 
 const prepareExtension = async (
   manifestPatch: ManifestPatch | undefined,
@@ -119,7 +178,7 @@ const prepareExtension = async (
 export const test = base.extend<TestFixtures>({
   extensionOptions: [{}, { option: true }],
 
-  extensionContext: async ({ extensionOptions }, provide) => {
+  extensionContext: async ({ extensionId, extensionOptions }, provide) => {
     const { extensionPath, temporaryDirectory } = await prepareExtension(
       extensionOptions.manifest,
     );
@@ -138,6 +197,7 @@ export const test = base.extend<TestFixtures>({
           ],
         },
       );
+      await verifyExtensionLoaded(context, extensionId);
       await provide(context);
     } finally {
       await context?.close();
@@ -145,12 +205,7 @@ export const test = base.extend<TestFixtures>({
     }
   },
 
-  extensionId:
-    // Playwright requires the fixture dependency argument to use object destructuring.
-    // oxlint-disable-next-line no-empty-pattern
-    async ({}, provide) => {
-      await provide(E2E_EXTENSION_ID);
-    },
+  extensionId: [E2E_EXTENSION_ID, { option: true }],
 
   extensionPage: async ({ extensionContext }, provide) => {
     const page = await extensionContext.newPage();

--- a/e2e/manifest.test.ts
+++ b/e2e/manifest.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+
+import { createExtensionId, patchManifest } from './manifest';
+
+const E2E_HOST_PERMISSION = 'https://example.com/*';
+
+describe('patchManifest', () => {
+  test('applies explicit removals and replacements', () => {
+    expect(
+      patchManifest(
+        {
+          action: {},
+          background: {},
+        },
+        {
+          remove: ['background'],
+          set: {
+            host_permissions: [E2E_HOST_PERMISSION],
+          },
+        },
+      ),
+    ).toEqual({
+      action: {},
+      host_permissions: [E2E_HOST_PERMISSION],
+    });
+  });
+
+  test('rejects a non-object manifest', () => {
+    expect(() => patchManifest([])).toThrow(
+      'Built extension manifest must be an object.',
+    );
+  });
+
+  test('rejects a missing removal target', () => {
+    expect(() =>
+      patchManifest(
+        {
+          background: {},
+        },
+        {
+          remove: ['options_ui'],
+        },
+      ),
+    ).toThrow('Manifest has no top-level field "options_ui" to remove.');
+  });
+
+  test('rejects duplicate removal targets', () => {
+    expect(() =>
+      patchManifest(
+        {
+          background: {},
+        },
+        {
+          remove: ['background', 'background'],
+        },
+      ),
+    ).toThrow(
+      'Manifest field "background" is listed more than once in remove.',
+    );
+  });
+
+  test('rejects fields configured by both remove and set', () => {
+    expect(() =>
+      patchManifest(
+        {
+          background: {},
+        },
+        {
+          remove: ['background'],
+          set: {
+            background: {
+              service_worker: 'replacement.js',
+            },
+          },
+        },
+      ),
+    ).toThrow(
+      'Manifest field "background" cannot be configured by both remove and set.',
+    );
+  });
+
+  test.each([
+    {
+      patch: {
+        remove: ['key'],
+      },
+    },
+    {
+      patch: {
+        set: {
+          key: 'another-key',
+        },
+      },
+    },
+  ])('rejects configuring the fixture-owned extension key', ({ patch }) => {
+    expect(() =>
+      patchManifest(
+        {
+          key: 'fixture-key',
+          name: 'extension',
+        },
+        patch,
+      ),
+    ).toThrow('Manifest field "key" is reserved by the E2E fixture.');
+  });
+});
+
+describe('createExtensionId', () => {
+  test('derives the Chrome extension ID from a manifest public key', () => {
+    expect(createExtensionId('dGVzdC1rZXk=')).toBe(
+      'gckpihaehgepkpiokicpmgbmojmemdja',
+    );
+  });
+});

--- a/e2e/manifest.ts
+++ b/e2e/manifest.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+
+const E2E_RESERVED_MANIFEST_FIELD = 'key';
+
+export type ManifestPatch = {
+  remove?: readonly string[];
+  set?: Readonly<Record<string, unknown>>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const patchManifest = (
+  manifest: unknown,
+  patch: ManifestPatch = {},
+): Record<string, unknown> => {
+  if (!isRecord(manifest)) {
+    throw new Error('Built extension manifest must be an object.');
+  }
+
+  const removeFields = patch.remove ?? [];
+  const setFields = new Set(Object.keys(patch.set ?? {}));
+  if (
+    removeFields.includes(E2E_RESERVED_MANIFEST_FIELD) ||
+    setFields.has(E2E_RESERVED_MANIFEST_FIELD)
+  ) {
+    throw new Error(
+      `Manifest field "${E2E_RESERVED_MANIFEST_FIELD}" is reserved by the E2E fixture.`,
+    );
+  }
+
+  const patchedManifest = { ...manifest };
+  const removedFields = new Set<string>();
+  for (const field of removeFields) {
+    if (removedFields.has(field)) {
+      throw new Error(
+        `Manifest field "${field}" is listed more than once in remove.`,
+      );
+    }
+    if (setFields.has(field)) {
+      throw new Error(
+        `Manifest field "${field}" cannot be configured by both remove and set.`,
+      );
+    }
+    if (!Object.hasOwn(patchedManifest, field)) {
+      throw new Error(`Manifest has no top-level field "${field}" to remove.`);
+    }
+
+    removedFields.add(field);
+    delete patchedManifest[field];
+  }
+
+  return {
+    ...patchedManifest,
+    ...patch.set,
+  };
+};
+
+// Chrome hashes the public key, takes the first 16 bytes, then maps each hex
+// digit 0-f to a-p to form the 32-character extension ID.
+export const createExtensionId = (manifestKey: string): string => {
+  const hashPrefix = createHash('sha256')
+    .update(Buffer.from(manifestKey, 'base64'))
+    .digest('hex')
+    .slice(0, 32);
+
+  return hashPrefix.replace(/[0-9a-f]/gu, (digit) =>
+    String.fromCharCode('a'.charCodeAt(0) + Number.parseInt(digit, 16)),
+  );
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  testMatch: '**/*.spec.ts',
   fullyParallel: false,
   workers: 1,
   forbidOnly: Boolean(process.env.CI),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    include: ['src/**/*.test.{ts,tsx}', 'scripts/**/*.test.mjs'],
+    include: [
+      'src/**/*.test.{ts,tsx}',
+      'scripts/**/*.test.mjs',
+      'e2e/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## 概要

- E2E fixture の拡張ID解決を background service worker 非依存に変更
- `test.use({ extensionOptions })` で manifest のトップレベル項目と Chromium context を構成可能に変更
- manifestパッチの誤指定と拡張ロード失敗を早期に明示エラー化
- content script E2E を本番URL + `page.route()` インターセプト方式へ変更
- content単独 / content+background / popup+options の3構成を実Chromiumで検証
- `.claude/rules/testing.md` とadapt-template手順に派生プロダクト向けの利用規約を追加

## 背景

従来の fixture は background service worker、`https://example.com/*` のmatches書き換え、ローカルHTTPサーバを前提としており、surface構成が変わるたびにfixture自体の書き換えが必要でした。テスト専用のmanifest keyから拡張IDを決定し、surface差分を設定引数で表現することで、ダミーbackgroundの注入を不要にしています。

レビュー対応として、存在しないremove対象、remove/set競合、予約keyの上書きを拒否し、persistent context提供前に拡張originをprobeするreadinessバリアを追加しました。

## 影響

派生プロダクトは `e2e/fixtures.ts` を変更せず、spec側の `extensionOptions.manifest.remove` / `set` と `contextOptions` だけで構成を切り替えられます。既存のpopup-background間typed messagingも継続検証しています。

## 検証

- TDD: manifestパッチの負系テストを先に追加し、Redを確認
- 不正manifest時に `Extension failed to load ... Check extensionOptions.manifest.` を返す負系実Chromium検収
- `npm run verify:full`
  - TypeScript: 成功
  - Oxlint: 成功
  - Vitest: 12ファイル / 42テスト成功
  - build / manifest検証: 成功
  - Playwright E2E: 9テスト成功

Closes #125