### PR TITLE
[ISSUE 130] docs: AGENTS.mdの派生更新契約を明文化

### DIFF
--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -176,8 +176,14 @@ with `npx playwright install chromium`.
 Classify every inherited document as **keep**, **rewrite for the product**, or
 **delete**. Do not leave a template claim because it is harmless-looking.
 
-- `AGENTS.md`: product name, retained surfaces, commands, architecture invariants,
-  recipes, verification table, and on-demand skill references
+- `AGENTS.md` has two machine-delimited contracts. The universal section from
+  `<!-- AGENTS:UNIVERSAL:BEGIN -->` through `<!-- AGENTS:UNIVERSAL:END -->` must be
+  preserved; do not rewrite it merely because product configuration changed. The
+  derivation-required section from `<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->`
+  through `<!-- AGENTS:DERIVATION-REQUIRED:END -->` must be updated, rewritten, or
+  pruned to match the product while retaining both boundary markers. Audit its
+  product name, surfaces, commands, shared layers, recipes, verification table, and
+  on-demand skill references.
 - `CLAUDE.md` and `.claude/rules/*.md`: product instructions, examples, and paths to
   deleted entrypoints or sample files
 - `README.md` and `docs/README.ja.md`: identity, capabilities, screenshots, quick

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -191,16 +191,20 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   product name, surfaces, commands, shared layers, repository conventions, recipes,
   verification table, and on-demand skill references.
 - A deliberate repository-independent change to the universal contract also requires
-  updating its canonical SHA-256 in `scripts/agent-doc-contract.mjs`; product
-  configuration alone is not a reason to change either value.
+  updating its canonical SHA-256 in `scripts/agent-doc-contract.mjs`. The validator
+  reports the expected and actual hashes; the value is SHA-256 of the trimmed text
+  between the universal markers. Product configuration alone is not a reason to
+  change either value.
 - Within the derivation-required section, describe only the surfaces and shared
   layers retained by the product. Remove recipes and forbidden-change notes for
   deleted infrastructure. Keep each command and verification mapping only when it
   exists in `package.json` and still proves the stated change type.
 - Update the JSON between `<!-- AGENTS:DERIVATION-METADATA:BEGIN -->` and
   `<!-- AGENTS:DERIVATION-METADATA:END -->`. Its `surfaces` must equal the directory
-  names under `src/entrypoints/`; its `paths` must name retained tracked files or
-  directories; and its `commands` must name retained `package.json` scripts.
+  names under `src/entrypoints/`, and its `sharedLayers` must equal the directory
+  names under `src/lib/`. These are the only metadata keys; literal paths and npm
+  commands in the surrounding prose are checked directly against the repository
+  tree and `package.json`.
 - Check every path named in the derivation-required section. A path to a deleted
   entrypoint, shared layer, test helper, rule, or skill is a failed adaptation even
   when all code checks pass.
@@ -212,7 +216,7 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   must not copy product facts that belong in the derivation-required section.
 - Run `npm test -- --run scripts/agent-doc-contract.test.mjs` after editing these
   files. It verifies the canonical universal content, marker structure, derivation
-  metadata, literal tracked paths, npm scripts, the single `@AGENTS.md` import, and
+  metadata, literal repository paths, npm scripts, the single `@AGENTS.md` import, and
   this skill's machine-readable contract anchors.
 
 ### Audit the remaining inherited documents
@@ -251,8 +255,8 @@ Adaptation is complete only when all of these are true:
 4. The built manifest contains only intended surfaces, permissions, URL matches, and
    generated resources.
 5. `npm test -- --run scripts/agent-doc-contract.test.mjs` passes; its canonical
-   universal-content check and derivation metadata/path/command checks match the
-   final tree.
+   universal-content check and derivation metadata plus literal path/command checks
+   match the final tree.
 6. No sample behavior, stale path, orphaned skill reference, placeholder, or
    unsupported documentation claim remains.
 7. The final report lists retained surfaces, deleted layers, effective permissions,

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -178,6 +178,10 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
 
 ### Update the agent contract
 
+<!-- AGENTS-CONTRACT:UNIVERSAL:PRESERVE -->
+
+<!-- AGENTS-CONTRACT:DERIVATION:SYNCHRONIZE -->
+
 - `AGENTS.md` has two machine-delimited contracts. The universal section from
   `<!-- AGENTS:UNIVERSAL:BEGIN -->` through `<!-- AGENTS:UNIVERSAL:END -->` must be
   preserved; do not rewrite it merely because product configuration changed. The
@@ -186,10 +190,17 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   pruned to match the product while retaining both boundary markers. Audit its
   product name, surfaces, commands, shared layers, repository conventions, recipes,
   verification table, and on-demand skill references.
+- A deliberate repository-independent change to the universal contract also requires
+  updating its canonical SHA-256 in `scripts/agent-doc-contract.mjs`; product
+  configuration alone is not a reason to change either value.
 - Within the derivation-required section, describe only the surfaces and shared
   layers retained by the product. Remove recipes and forbidden-change notes for
   deleted infrastructure. Keep each command and verification mapping only when it
   exists in `package.json` and still proves the stated change type.
+- Update the JSON between `<!-- AGENTS:DERIVATION-METADATA:BEGIN -->` and
+  `<!-- AGENTS:DERIVATION-METADATA:END -->`. Its `surfaces` must equal the directory
+  names under `src/entrypoints/`; its `paths` must name retained tracked files or
+  directories; and its `commands` must name retained `package.json` scripts.
 - Check every path named in the derivation-required section. A path to a deleted
   entrypoint, shared layer, test helper, rule, or skill is a failed adaptation even
   when all code checks pass.
@@ -200,8 +211,9 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
 - Keep `CLAUDE.md` as the single `@AGENTS.md` import. It may explain discovery, but
   must not copy product facts that belong in the derivation-required section.
 - Run `npm test -- --run scripts/agent-doc-contract.test.mjs` after editing these
-  files. It proves that both marker pairs remain unique, ordered, non-empty, and
-  synchronized with `CLAUDE.md` and this skill.
+  files. It verifies the canonical universal content, marker structure, derivation
+  metadata, literal tracked paths, npm scripts, the single `@AGENTS.md` import, and
+  this skill's machine-readable contract anchors.
 
 ### Audit the remaining inherited documents
 
@@ -238,9 +250,9 @@ Adaptation is complete only when all of these are true:
 3. `npm run verify:full` passes against the final selected surfaces.
 4. The built manifest contains only intended surfaces, permissions, URL matches, and
    generated resources.
-5. `npm test -- --run scripts/agent-doc-contract.test.mjs` passes; the universal
-   section is unchanged by product-configuration edits, and the derivation-required
-   section matches the final tree.
+5. `npm test -- --run scripts/agent-doc-contract.test.mjs` passes; its canonical
+   universal-content check and derivation metadata/path/command checks match the
+   final tree.
 6. No sample behavior, stale path, orphaned skill reference, placeholder, or
    unsupported documentation claim remains.
 7. The final report lists retained surfaces, deleted layers, effective permissions,

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -184,8 +184,8 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   derivation-required section from `<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->`
   through `<!-- AGENTS:DERIVATION-REQUIRED:END -->` must be updated, rewritten, or
   pruned to match the product while retaining both boundary markers. Audit its
-  product name, surfaces, commands, shared layers, recipes, verification table, and
-  on-demand skill references.
+  product name, surfaces, commands, shared layers, repository conventions, recipes,
+  verification table, and on-demand skill references.
 - Within the derivation-required section, describe only the surfaces and shared
   layers retained by the product. Remove recipes and forbidden-change notes for
   deleted infrastructure. Keep each command and verification mapping only when it

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -176,6 +176,8 @@ with `npx playwright install chromium`.
 Classify every inherited document as **keep**, **rewrite for the product**, or
 **delete**. Do not leave a template claim because it is harmless-looking.
 
+### Update the agent contract
+
 - `AGENTS.md` has two machine-delimited contracts. The universal section from
   `<!-- AGENTS:UNIVERSAL:BEGIN -->` through `<!-- AGENTS:UNIVERSAL:END -->` must be
   preserved; do not rewrite it merely because product configuration changed. The
@@ -184,8 +186,27 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   pruned to match the product while retaining both boundary markers. Audit its
   product name, surfaces, commands, shared layers, recipes, verification table, and
   on-demand skill references.
-- `CLAUDE.md` and `.claude/rules/*.md`: product instructions, examples, and paths to
-  deleted entrypoints or sample files
+- Within the derivation-required section, describe only the surfaces and shared
+  layers retained by the product. Remove recipes and forbidden-change notes for
+  deleted infrastructure. Keep each command and verification mapping only when it
+  exists in `package.json` and still proves the stated change type.
+- Check every path named in the derivation-required section. A path to a deleted
+  entrypoint, shared layer, test helper, rule, or skill is a failed adaptation even
+  when all code checks pass.
+- Rebuild the on-demand context table from the files that remain. Every row must
+  point to an existing, applicable rule or skill. Review every retained file under
+  `.claude/skills/`; update or delete a skill that is no longer reachable from the
+  table or automatic discovery and no longer describes supported product work.
+- Keep `CLAUDE.md` as the single `@AGENTS.md` import. It may explain discovery, but
+  must not copy product facts that belong in the derivation-required section.
+- Run `npm test -- --run scripts/agent-doc-contract.test.mjs` after editing these
+  files. It proves that both marker pairs remain unique, ordered, non-empty, and
+  synchronized with `CLAUDE.md` and this skill.
+
+### Audit the remaining inherited documents
+
+- `.claude/rules/*.md`: update examples and paths to deleted entrypoints or sample
+  files
 - `README.md` and `docs/README.ja.md`: identity, capabilities, screenshots, quick
   start, development paths, permissions, and release instructions
 - `docs/adr/`: retain decisions the product still adopts, rewrite product-specific
@@ -194,8 +215,6 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   and response expectations
 - `docs/releasing.md`, `docs/releasing.ja.md`, and
   `.claude/skills/release/SKILL.md`: actual release and distribution policy
-- `.claude/skills/add-entrypoint/SKILL.md` and the AGENTS.md on-demand table: remove or
-  update references to deleted wiring and skills
 - `docs/store/privacy-policy.md`, `store-listing.md`, and `manual-test.md`: replace
   every placeholder and HTML comment before a Store release; reconcile permissions
   with the built manifest and stored data with the implementation
@@ -219,7 +238,10 @@ Adaptation is complete only when all of these are true:
 3. `npm run verify:full` passes against the final selected surfaces.
 4. The built manifest contains only intended surfaces, permissions, URL matches, and
    generated resources.
-5. No sample behavior, stale path, placeholder, or unsupported documentation claim
-   remains.
-6. The final report lists retained surfaces, deleted layers, effective permissions,
+5. `npm test -- --run scripts/agent-doc-contract.test.mjs` passes; the universal
+   section is unchanged by product-configuration edits, and the derivation-required
+   section matches the final tree.
+6. No sample behavior, stale path, orphaned skill reference, placeholder, or
+   unsupported documentation claim remains.
+7. The final report lists retained surfaces, deleted layers, effective permissions,
    persistence, verification commands, and any deliberately deferred Store work.

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -214,12 +214,12 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   look path-like. Spans containing whitespace are command candidates instead, which
   avoids treating `node scripts/example.mjs` as one path; npm script names are also
   checked against `package.json`.
-- Repository collection deliberately excludes root-level generated and local-only
-  paths such as `dist`, `extension`, dependency/cache directories, `.env`, logs, and
-  package archives. Limit these basename exclusions to the repository root so a real
-  source directory such as `src/lib/logs/` remains visible. When `.gitignore` gains
-  another root-level generated-output family that could mask a stale documentation
-  path, update the ignore sets in
+- Repository collection excludes `.git` and `node_modules` directories at every
+  depth. Other generated and local-only paths such as root-level `dist`, `extension`,
+  cache directories, `.env`, logs, and package archives are excluded only at the
+  repository root so a real source directory such as `src/lib/logs/` remains visible.
+  When `.gitignore` gains another root-level generated-output family that could mask
+  a stale documentation path, update the ignore sets in
   `scripts/agent-doc-contract.mjs` and its test in the same change.
 - Rebuild the on-demand context table from the files that remain. Every row must
   point to an existing, applicable rule or skill. Review every retained file under

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -214,10 +214,12 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   look path-like. Spans containing whitespace are command candidates instead, which
   avoids treating `node scripts/example.mjs` as one path; npm script names are also
   checked against `package.json`.
-- Repository collection deliberately excludes generated and local-only paths such as
-  `dist`, `extension`, dependency/cache directories, `.env`, logs, and package
-  archives. When `.gitignore` gains another generated-output family that could mask
-  a stale documentation path, update the ignore sets in
+- Repository collection deliberately excludes root-level generated and local-only
+  paths such as `dist`, `extension`, dependency/cache directories, `.env`, logs, and
+  package archives. Limit these basename exclusions to the repository root so a real
+  source directory such as `src/lib/logs/` remains visible. When `.gitignore` gains
+  another root-level generated-output family that could mask a stale documentation
+  path, update the ignore sets in
   `scripts/agent-doc-contract.mjs` and its test in the same change.
 - Rebuild the on-demand context table from the files that remain. Every row must
   point to an existing, applicable rule or skill. Review every retained file under

--- a/.claude/skills/adapt-template/SKILL.md
+++ b/.claude/skills/adapt-template/SKILL.md
@@ -200,18 +200,35 @@ Classify every inherited document as **keep**, **rewrite for the product**, or
   deleted infrastructure. Keep each command and verification mapping only when it
   exists in `package.json` and still proves the stated change type.
 - Update the JSON between `<!-- AGENTS:DERIVATION-METADATA:BEGIN -->` and
-  `<!-- AGENTS:DERIVATION-METADATA:END -->`. Its `surfaces` must equal the directory
-  names under `src/entrypoints/`, and its `sharedLayers` must equal the directory
-  names under `src/lib/`. These are the only metadata keys; literal paths and npm
-  commands in the surrounding prose are checked directly against the repository
-  tree and `package.json`.
+  `<!-- AGENTS:DERIVATION-METADATA:END -->`. Set `entrypointRoot` and `sharedRoot`
+  to the product's actual repository paths, then make `surfaces` and `sharedLayers`
+  equal their immediate child-directory names. Use `null` for `sharedRoot` only when
+  the product has no shared-module directory, and keep `sharedLayers` empty with it.
+  These are the only metadata keys. The validator rejects a configured root that
+  does not exist, so a layout rename cannot silently reduce the contract to empty
+  arrays.
 - Check every path named in the derivation-required section. A path to a deleted
   entrypoint, shared layer, test helper, rule, or skill is a failed adaptation even
   when all code checks pass.
+- Inline code spans without whitespace are treated as repository paths when they
+  look path-like. Spans containing whitespace are command candidates instead, which
+  avoids treating `node scripts/example.mjs` as one path; npm script names are also
+  checked against `package.json`.
+- Repository collection deliberately excludes generated and local-only paths such as
+  `dist`, `extension`, dependency/cache directories, `.env`, logs, and package
+  archives. When `.gitignore` gains another generated-output family that could mask
+  a stale documentation path, update the ignore sets in
+  `scripts/agent-doc-contract.mjs` and its test in the same change.
 - Rebuild the on-demand context table from the files that remain. Every row must
   point to an existing, applicable rule or skill. Review every retained file under
   `.claude/skills/`; update or delete a skill that is no longer reachable from the
   table or automatic discovery and no longer describes supported product work.
+- Keep `adapt-template` and its derivation-section reference while adaptation is in
+  progress. After the product contract is complete and verified, the final cleanup
+  may delete this skill and remove every reference to it. The contract test reads the
+  skill optionally: when it remains, its anchors and derivation reference are
+  required; when it is deleted, skill-specific checks are skipped while all AGENTS,
+  path, metadata, command, and CLAUDE checks continue to run.
 - Keep `CLAUDE.md` as the single `@AGENTS.md` import. It may explain discovery, but
   must not copy product facts that belong in the derivation-required section.
 - Run `npm test -- --run scripts/agent-doc-contract.test.mjs` after editing these

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,34 @@
-# crx-vite-ts-react-template
+<!-- AGENTS:UNIVERSAL:BEGIN -->
 
-Chrome extension (Manifest V3) template built with Vite + TypeScript + React.
-Surfaces: popup, options page, background service worker, content script — each
-lives under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options)
-load `src/entrypoints/<surface>/<surface>.tsx`; the manifest is generated from
-`manifest.config.ts` via `@crxjs/vite-plugin`; `npm run build` outputs to
-`extension/` (gitignored). `src/lib/` holds shared modules entrypoints may
-import (never the reverse); `src/examples/` holds deletable sample code. See
-README's "Architecture" section for the full dependency-direction rules.
+# Universal collaboration contract
 
-## Commands
-
-| Command | What it does | Notes |
-| --- | --- | --- |
-| `npm ci` | Install deps | 407 packages, verified OK |
-| `npm run dev` | Vite dev server with HMR | via `@crxjs/vite-plugin` |
-| `npm run build` | Build to `extension/` | deletes and recreates the dir |
-| `npm run package` | Build, verify manifest, create reproducible `extension.zip` | archives distributable files from `extension/` |
-| `npm run verify` | check-type → lint → test → build → verify:manifest, in series | the safety contract for most changes; excludes e2e for speed |
-| `npm run verify:full` | `verify` then `npm run e2e` | full contract; requires installed Chromium |
-| `npm run e2e` | Run Playwright Chromium smoke tests | requires a prior build and installed Chromium |
-| `npm run render:icons` | Render 16/48/128 px normal/dev PNG icons from SVG sources | requires installed Chromium |
-| `npm run check-type` | `tsc --noEmit` | |
-| `npm test` | Run Vitest | src tests use jsdom; script and e2e helper tests use Node |
-| `npm run lint` | `oxlint` (check-only) | no file mutation; pre-commit runs the staged-only equivalent via lint-staged |
-| `npm run format` | `prettier --write` | rewrites files on disk; pre-commit runs the staged-only equivalent via lint-staged |
-| `npm run zip` | Alias for `npm run package` | |
-
-`.nvmrc` pins Node 24, matching the `engines.node` (`>=24.0.0`) requirement.
+This section contains repository-independent working rules that remain applicable
+after this template becomes a product. Do not change it merely because product
+surfaces, shared layers, or inherited documents change.
 
 ## Verification contract
 
-After changing code, prove it is safe with a single command. **The source of truth
-is the checks themselves** (types, lint, tests, `verify:manifest`) — this section
-only tells you which to run.
+After changing code or documentation, prove the result with the repository's
+relevant checks. The checks themselves (types, lint, tests, build, and contract
+verification) are the source of truth; prose only explains which gate to run.
 
-- `npm run verify` — check-type → lint → test → build → verify:manifest, in series.
-  This is the contract for most changes. `verify:manifest` reads the built
-  `extension/manifest.json`, so `build` always runs before it. e2e is excluded here
-  because it needs a real Chromium and is slow.
-- `npm run verify:full` — `verify` then `npm run e2e` (real Chromium smoke tests).
-  Run this when your change could affect the built extension's runtime wiring.
-
-Minimum verification per change type:
-
-| Change | Run |
-| --- | --- |
-| `src/lib/**`, types, unit tests, `src/examples/**` | `npm run verify` |
-| `manifest.config.ts`, permissions, CSP | `npm run verify` (asserts the manifest) |
-| entrypoint wiring, messaging/storage round-trips, anything e2e exercises | `npm run verify:full` |
-
-CI is not changed by this file: it already runs the same underlying checks as
-separate jobs. `verify` / `verify:full` are the local and agent-facing entry points.
+- Prefer one top-level verification command that runs the required checks in order.
+- Use the fast verification gate for shared code, types, unit tests, manifest
+  declarations, and documentation contracts.
+- Use the full verification gate when runtime wiring, messaging, storage
+  round-trips, or browser behavior may have changed.
+- A passing command is not sufficient when it warns that a template default,
+  placeholder, or stale contract remains.
 
 ## Architecture invariants
 
-These hold regardless of the task. Where a check enforces an invariant, that check —
-not this file — is the authority; the note explains the intent a check cannot.
-
 - **Dependency direction is `entrypoints → lib` only; `lib` never imports from
-  `entrypoints`.** `src/lib/` stays reusable and unit-testable in isolation
-  (with `installChromeFake` from `src/lib/testing/chromeFake.ts`); a back-edge would
-  couple shared code to one surface.
-- **Entrypoints do not import each other directly.** Surfaces are separate runtime
-  contexts (popup / options / background / content); they communicate through the
-  typed messaging layer in `src/lib/messaging/`, not shared module state.
+  `entrypoints`.** Shared code stays reusable and unit-testable in isolation (with
+  `installChromeFake` from `src/lib/testing/chromeFake.ts`); a back-edge couples it
+  to one runtime surface.
+- **Entrypoints do not import each other directly.** Extension surfaces are separate
+  runtime contexts and communicate through an explicit messaging boundary rather
+  than shared module state.
 - **Real `chrome.*` access lives only inside `src/lib/`.** Outside `src/lib/**`,
   referencing the `chrome` global is an Oxlint error (`no-restricted-globals` /
   `no-restricted-properties` override in `.oxlintrc.json`); route the call through a
@@ -72,83 +36,149 @@ not this file — is the authority; the note explains the intent a check cannot.
   (`@types/chrome`) are allowed everywhere. An unavoidable exception must carry a
   reasoned `oxlint-disable` comment so the boundary violation stays visible.
 
-## Recipes
-
-Minimal, real code paths for the common changes. Each recipe ends with the
-verification its change type calls for in **Verification contract** above — not a
-blanket command.
-
-- **Add a message type.** In `src/lib/messaging/messages.ts`, add one entry to
-  `messages` via `defineMessage(isRequest, isResponse)` (hand-written type-guard
-  predicates — no runtime schema dependency). Register the handler in
-  `src/entrypoints/background/background.ts` under `addMessageListeners({ ... })`, and
-  send from a surface with `sendMessage(name, payload)`. The generic engine in
-  `createMessaging.ts` needs no change; sender check and payload guards are automatic.
-  This touches entrypoint wiring (`background.ts` + a surface), so verify with
-  **`npm run verify:full`** — only the real-Chromium e2e exercises the messaging round-trip.
-- **Add a storage key.** In `src/lib/storage/schema.ts`, add the key to the
-  `AppStorageValues` type and to `storageSchema` (`area` + `defaultValue`). Everything
-  else (`getStorageValue` / `setStorageValue` / `removeStorageValue` /
-  `onStorageValueChanged` / `useStorageValue`) is generic and follows automatically.
-  The schema edit is `src/lib/**`-only, so **`npm run verify`** covers it; if you also
-  wire a surface to read or write the key, verify that with `npm run verify:full`.
-- **Add a Chrome permission.** Add it to `permissions` (or `host_permissions` /
-  `optional_permissions`) in `manifest.config.ts`, **and** update the matching array
-  in `scripts/expected-manifest.config.mjs`. A mismatch makes `verify:manifest` fail
-  by design — that failure is the guard against silent privilege growth. Surface,
-  content-script, and web-accessible-resource expectations live in the same file;
-  do not modify the generic engine for a product-specific manifest shape.
-  **`npm run verify`** asserts it.
-
-## Forbidden changes
-
-Do not make these without explicit owner sign-off. Most are enforced by
-`scripts/verify-manifest.mjs`, which fails the build on violation:
-
-- Adding a manifest `permission` / `host_permission` without updating the matching
-  array in `scripts/expected-manifest.config.mjs` (and without a reason to hold the
-  new privilege).
-- Adding an external runtime dependency to `src/lib/` — the messaging and storage
-  layers are dependency-free by design; keep them so.
-- Relaxing the CSP. The generic engine pins
-  `content_security_policy.extension_pages` to `script-src 'self'; object-src 'self';`;
-  `expected-manifest.config.mjs` cannot override it.
-- Declaring `externally_connectable` — the generic engine rejects it outright, and
-  `expected-manifest.config.mjs` cannot permit it.
-
 ## Conventions
 
-- Named exports only, no default exports — except `*.config.ts` (`vite.config.ts`, `manifest.config.ts`, `playwright.config.ts`, `vitest.config.ts`), which must keep `export default` because Vite/CRXJS/Playwright/Vitest require it to load the config.
+- Named exports only, no default exports — except `*.config.ts` (`vite.config.ts`,
+  `manifest.config.ts`, `playwright.config.ts`, `vitest.config.ts`), which keep
+  `export default` because their tools require it.
 - Components are arrow functions.
-- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or `*.test.mjs` next to Node scripts; E2E helper unit tests live under `e2e/` as `*.test.ts` with the Node environment pragma, while Playwright smoke tests use `*.spec.ts`.
+- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or
+  `*.test.mjs` next to Node scripts; E2E helper unit tests live under `e2e/` as
+  `*.test.ts` with the Node environment pragma, while Playwright smoke tests use
+  `*.spec.ts`.
 - Hooks return tuples `as const` (state, action).
-- Everything else (formatting, quote style, etc.) is enforced by Oxlint/Prettier/tsc — run them, don't hand-check. Import order is not lint-enforced (no Oxlint equivalent to the old `import/order`); keep imports reasonably grouped by convention.
-
-## On-demand context
-
-Read these only when the row matches your task — they are excluded from the always-loaded context by design.
-
-| When you are... | Read |
-| --- | --- |
-| editing any `.ts`/`.tsx` file | `.claude/rules/typescript-react.md` |
-| touching `manifest.config.ts`, background, or content scripts | `.claude/rules/chrome-extension.md` |
-| writing tests | `.claude/rules/testing.md` |
-| adding an extension surface (popup/options/background/content script) | `.claude/skills/add-entrypoint/SKILL.md` |
-| pruning surfaces, setting product identity, or auditing inherited docs while turning this template into a real extension | `.claude/skills/adapt-template/SKILL.md` |
-| releasing/packaging/deploying | `.claude/skills/release/SKILL.md` |
+- Formatting, quote style, and static checks are enforced by Oxlint, Prettier, and
+  tsc; run them instead of hand-checking. Import order is not lint-enforced; keep
+  imports reasonably grouped by convention.
 
 ## Git
 
 - Stage files individually; never `git add -A` / `git add .`.
 - Use Conventional Commit types: feat, fix, docs, style, refactor, test, chore.
-- Commit body records WHY, not what.
+- Commit bodies record WHY, not what.
 
 ## Responses
 
-Reply in Japanese, conclusion first, concise. No greetings, emoji, or progress narration. Point out problems bluntly.
+Reply in Japanese, conclusion first, concise. No greetings, emoji, or progress
+narration. Point out problems bluntly.
 
 ## Safety
 
 - Destructive ops (rm -rf, force-push, history rewrite) need explicit user approval.
 - Never read, print, or commit secrets.
-- If the user corrects the same mistake twice, append the correction to the matching `.claude/rules/*.md` file.
+- If the user corrects the same mistake twice, append the correction to the matching
+  `.claude/rules/*.md` file.
+
+<!-- AGENTS:UNIVERSAL:END -->
+
+<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->
+
+# crx-vite-ts-react-template
+
+> **Derived products must update this entire section.** Keep the boundary markers,
+> but rewrite or delete every claim that no longer matches the retained surfaces,
+> shared layers, commands, recipes, and on-demand references. Follow
+> `.claude/skills/adapt-template/SKILL.md`; a passing build does not excuse stale
+> agent instructions.
+
+Chrome extension (Manifest V3) template built with Vite + TypeScript + React.
+Surfaces: popup, options page, background service worker, content script — each lives
+under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options) load
+`src/entrypoints/<surface>/<surface>.tsx`; the manifest is generated from
+`manifest.config.ts` via `@crxjs/vite-plugin`; `npm run build` outputs to
+`extension/` (gitignored). `src/lib/` holds shared modules entrypoints may import
+(never the reverse); `src/examples/` holds deletable sample code. See README's
+"Architecture" section for the full dependency-direction rules.
+
+## Commands
+
+| Command                | What it does                                                  | Notes                                                                              |
+| ---------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `npm ci`               | Install deps                                                  | installs exactly from `package-lock.json`                                          |
+| `npm run dev`          | Vite dev server with HMR                                      | via `@crxjs/vite-plugin`                                                           |
+| `npm run build`        | Build to `extension/`                                         | deletes and recreates the dir                                                      |
+| `npm run package`      | Build, verify manifest, create reproducible `extension.zip`   | archives distributable files from `extension/`                                     |
+| `npm run verify`       | check-type → lint → test → build → verify:manifest, in series | the safety contract for most changes; excludes e2e for speed                       |
+| `npm run verify:full`  | `verify` then `npm run e2e`                                   | full contract; requires installed Chromium                                         |
+| `npm run e2e`          | Run Playwright Chromium smoke tests                           | requires a prior build and installed Chromium                                      |
+| `npm run render:icons` | Render 16/48/128 px normal/dev PNG icons from SVG sources     | requires installed Chromium                                                        |
+| `npm run check-type`   | `tsc --noEmit`                                                |                                                                                    |
+| `npm test`             | Run Vitest                                                    | src tests use jsdom; script and e2e helper tests use Node                          |
+| `npm run lint`         | `oxlint` (check-only)                                         | no file mutation; pre-commit runs the staged-only equivalent via lint-staged       |
+| `npm run format`       | `prettier --write`                                            | rewrites files on disk; pre-commit runs the staged-only equivalent via lint-staged |
+| `npm run zip`          | Alias for `npm run package`                                   |                                                                                    |
+
+`.nvmrc` pins Node 24, matching the `engines.node` (`>=24.0.0`) requirement.
+
+### Verification gates for this repository
+
+- `npm run verify` runs check-type, lint, unit tests, build, and manifest
+  verification in order. `verify:manifest` reads the built
+  `extension/manifest.json`, so build always runs first.
+- `npm run verify:full` runs `verify` and the real-Chromium E2E suite.
+
+| Change                                                                       | Run                                     |
+| ---------------------------------------------------------------------------- | --------------------------------------- |
+| `src/lib/**`, types, unit tests, `src/examples/**`, agent-document contracts | `npm run verify`                        |
+| `manifest.config.ts`, permissions, CSP                                       | `npm run verify` (asserts the manifest) |
+| entrypoint wiring, messaging/storage round-trips, anything E2E exercises     | `npm run verify:full`                   |
+
+CI already runs the same underlying checks as separate jobs.
+
+## Product architecture
+
+- `src/lib/` is reusable shared infrastructure. Tests that need Chrome APIs use
+  `installChromeFake` from `src/lib/testing/chromeFake.ts`.
+- Popup, options, background, and content entrypoints communicate through the typed
+  messaging layer in `src/lib/messaging/`.
+- The Oxlint restrictions in `.oxlintrc.json` enforce the `chrome.*` access boundary.
+
+## Recipes
+
+Minimal, real code paths for common changes:
+
+- **Add a message type.** In `src/lib/messaging/messages.ts`, add one entry to
+  `messages` via `defineMessage(isRequest, isResponse)` (hand-written type-guard
+  predicates; no runtime schema dependency). Register the handler in
+  `src/entrypoints/background/background.ts` under `addMessageListeners({ ... })`,
+  and send from a surface with `sendMessage(name, payload)`. The generic engine in
+  `createMessaging.ts` needs no change. Run `npm run verify:full` because only the
+  real-Chromium E2E exercises the round-trip.
+- **Add a storage key.** Add the key to `AppStorageValues` and `storageSchema` in
+  `src/lib/storage/schema.ts` (`area` plus `defaultValue`). Generic accessors and
+  `useStorageValue` follow automatically. Run `npm run verify`; use `verify:full`
+  when a surface is wired to the key.
+- **Add a Chrome permission.** Update `permissions`, `host_permissions`, or
+  `optional_permissions` in `manifest.config.ts` and the matching array in
+  `scripts/expected-manifest.config.mjs` atomically. The mismatch failure guards
+  against silent privilege growth. Do not modify the generic engine for a
+  product-specific manifest shape. Run `npm run verify`.
+
+## Forbidden changes
+
+Do not make these without explicit owner sign-off:
+
+- Adding a manifest permission or host permission without updating the matching
+  array in `scripts/expected-manifest.config.mjs` and documenting why it is needed.
+- Adding an external runtime dependency to `src/lib/`; the messaging and storage
+  layers are dependency-free by design.
+- Relaxing the extension-pages CSP from
+  `script-src 'self'; object-src 'self';`. The expectation config cannot override
+  this invariant.
+- Declaring `externally_connectable`; the generic verifier rejects it and the
+  expectation config cannot permit it.
+
+## On-demand context
+
+Read these only when the row matches the task:
+
+| When you are...                                                                                                          | Read                                     |
+| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| editing any `.ts`/`.tsx` file                                                                                            | `.claude/rules/typescript-react.md`      |
+| touching `manifest.config.ts`, background, or content scripts                                                            | `.claude/rules/chrome-extension.md`      |
+| writing tests                                                                                                            | `.claude/rules/testing.md`               |
+| adding an extension surface (popup/options/background/content script)                                                    | `.claude/skills/add-entrypoint/SKILL.md` |
+| pruning surfaces, setting product identity, or auditing inherited docs while turning this template into a real extension | `.claude/skills/adapt-template/SKILL.md` |
+| releasing/packaging/deploying                                                                                            | `.claude/skills/release/SKILL.md`        |
+
+<!-- AGENTS:DERIVATION-REQUIRED:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,8 @@ verification) are the source of truth; prose only explains which gate to run.
 ## Architecture invariants
 
 - **Dependency direction is `entrypoints → lib` only; `lib` never imports from
-  `entrypoints`.** Shared code stays reusable and unit-testable in isolation (with
-  `installChromeFake` from `src/lib/testing/chromeFake.ts`); a back-edge couples it
-  to one runtime surface.
+  `entrypoints`.** Shared code stays reusable and unit-testable in isolation; a
+  back-edge couples it to one runtime surface.
 - **Entrypoints do not import each other directly.** Extension surfaces are separate
   runtime contexts and communicate through an explicit messaging boundary rather
   than shared module state.
@@ -38,18 +37,14 @@ verification) are the source of truth; prose only explains which gate to run.
 
 ## Conventions
 
-- Named exports only, no default exports — except `*.config.ts` (`vite.config.ts`,
-  `manifest.config.ts`, `playwright.config.ts`, `vitest.config.ts`), which keep
-  `export default` because their tools require it.
+- Named exports only, no default exports — except configuration files whose tools
+  require a default export.
 - Components are arrow functions.
-- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or
-  `*.test.mjs` next to Node scripts; E2E helper unit tests live under `e2e/` as
-  `*.test.ts` with the Node environment pragma, while Playwright smoke tests use
-  `*.spec.ts`.
+- Unit tests are colocated with source; helper and browser tests use the
+  repository-defined locations and environments.
 - Hooks return tuples `as const` (state, action).
-- Formatting, quote style, and static checks are enforced by Oxlint, Prettier, and
-  tsc; run them instead of hand-checking. Import order is not lint-enforced; keep
-  imports reasonably grouped by convention.
+- Formatting, quote style, and static checks are enforced by the configured tools;
+  run them instead of hand-checking.
 
 ## Git
 
@@ -67,7 +62,7 @@ narration. Point out problems bluntly.
 - Destructive ops (rm -rf, force-push, history rewrite) need explicit user approval.
 - Never read, print, or commit secrets.
 - If the user corrects the same mistake twice, append the correction to the matching
-  `.claude/rules/*.md` file.
+  repository rule file.
 
 <!-- AGENTS:UNIVERSAL:END -->
 
@@ -124,6 +119,18 @@ under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options) load
 | entrypoint wiring, messaging/storage round-trips, anything E2E exercises     | `npm run verify:full`                   |
 
 CI already runs the same underlying checks as separate jobs.
+
+## Repository conventions
+
+- The default-export exceptions are `vite.config.ts`, `manifest.config.ts`,
+  `playwright.config.ts`, and `vitest.config.ts` because their tools require them.
+- Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or
+  `*.test.mjs` next to Node scripts. E2E helper unit tests live under `e2e/` as
+  `*.test.ts` with the Node environment pragma; Playwright smoke tests use
+  `*.spec.ts`.
+- Oxlint, Prettier, and tsc enforce the repository style. Import order is not
+  lint-enforced; keep imports reasonably grouped.
+- Repeated user corrections are recorded in the matching `.claude/rules/*.md` file.
 
 ## Product architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,8 @@ verification) are the source of truth; prose only explains which gate to run.
 
 - Named exports only, no default exports — except configuration files whose tools
   require a default export.
-- Components are arrow functions.
 - Unit tests are colocated with source; helper and browser tests use the
   repository-defined locations and environments.
-- Hooks return tuples `as const` (state, action).
 - Formatting, quote style, and static checks are enforced by the configured tools;
   run them instead of hand-checking.
 
@@ -77,39 +75,7 @@ narration. Point out problems bluntly.
 ```json
 {
   "surfaces": ["background", "content", "options", "popup"],
-  "sharedLayers": ["messaging", "storage", "testing"],
-  "paths": [
-    "AGENTS.md",
-    "CLAUDE.md",
-    ".claude/skills/adapt-template/SKILL.md",
-    "manifest.config.ts",
-    "options.html",
-    "popup.html",
-    "scripts/agent-doc-contract.mjs",
-    "scripts/agent-doc-contract.test.mjs",
-    "scripts/expected-manifest.config.mjs",
-    "src/entrypoints/background/background.ts",
-    "src/entrypoints/content/sample.tsx",
-    "src/entrypoints/options/options.tsx",
-    "src/entrypoints/popup/popup.tsx",
-    "src/lib/messaging/messages.ts",
-    "src/lib/storage/schema.ts"
-  ],
-  "commands": [
-    "build",
-    "check-type",
-    "dev",
-    "e2e",
-    "format",
-    "lint",
-    "package",
-    "render:icons",
-    "test",
-    "verify",
-    "verify:full",
-    "verify:manifest",
-    "zip"
-  ]
+  "sharedLayers": ["messaging", "storage", "testing"]
 }
 ```
 
@@ -161,6 +127,8 @@ CI already runs the same underlying checks as separate jobs.
 
 ## Repository conventions
 
+- Components are arrow functions.
+- Hooks return tuples `as const` (state, action).
 - The default-export exceptions are `vite.config.ts`, `manifest.config.ts`,
   `playwright.config.ts`, and `vitest.config.ts` because their tools require them.
 - Unit tests are colocated as `*.test.ts(x)` next to TypeScript source or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,28 +12,25 @@ After changing code or documentation, prove the result with the repository's
 relevant checks. The checks themselves (types, lint, tests, build, and contract
 verification) are the source of truth; prose only explains which gate to run.
 
-- Prefer one top-level verification command that runs the required checks in order.
-- Use the fast verification gate for shared code, types, unit tests, manifest
-  declarations, and documentation contracts.
-- Use the full verification gate when runtime wiring, messaging, storage
-  round-trips, or browser behavior may have changed.
+- Prefer the repository-defined top-level verification command that runs the
+  required checks in order.
+- Use the repository's full verification gate when runtime wiring or browser
+  behavior may have changed.
 - A passing command is not sufficient when it warns that a template default,
   placeholder, or stale contract remains.
 
 ## Architecture invariants
 
-- **Dependency direction is `entrypoints → lib` only; `lib` never imports from
-  `entrypoints`.** Shared code stays reusable and unit-testable in isolation; a
-  back-edge couples it to one runtime surface.
+- **Dependency direction is runtime entrypoints → shared modules only.** Shared
+  modules never import runtime entrypoints; a back-edge couples reusable code to one
+  surface.
 - **Entrypoints do not import each other directly.** Extension surfaces are separate
   runtime contexts and communicate through an explicit messaging boundary rather
   than shared module state.
-- **Real `chrome.*` access lives only inside `src/lib/`.** Outside `src/lib/**`,
-  referencing the `chrome` global is an Oxlint error (`no-restricted-globals` /
-  `no-restricted-properties` override in `.oxlintrc.json`); route the call through a
-  thin `src/lib/` wrapper instead. Type-only references via the `chrome` namespace
-  (`@types/chrome`) are allowed everywhere. An unavoidable exception must carry a
-  reasoned `oxlint-disable` comment so the boundary violation stays visible.
+- **Direct browser API access is centralized in the designated shared boundary and
+  enforced by lint.** Type-only API references are allowed outside that boundary.
+  An unavoidable runtime exception must carry a reasoned lint-disable comment so the
+  boundary violation stays visible.
 
 ## Conventions
 
@@ -61,8 +58,7 @@ narration. Point out problems bluntly.
 
 - Destructive ops (rm -rf, force-push, history rewrite) need explicit user approval.
 - Never read, print, or commit secrets.
-- If the user corrects the same mistake twice, append the correction to the matching
-  repository rule file.
+- Record a repeated user correction in the repository's persistent instructions.
 
 <!-- AGENTS:UNIVERSAL:END -->
 
@@ -76,10 +72,53 @@ narration. Point out problems bluntly.
 > `.claude/skills/adapt-template/SKILL.md`; a passing build does not excuse stale
 > agent instructions.
 
+<!-- AGENTS:DERIVATION-METADATA:BEGIN -->
+
+```json
+{
+  "surfaces": ["background", "content", "options", "popup"],
+  "sharedLayers": ["messaging", "storage", "testing"],
+  "paths": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/skills/adapt-template/SKILL.md",
+    "manifest.config.ts",
+    "options.html",
+    "popup.html",
+    "scripts/agent-doc-contract.mjs",
+    "scripts/agent-doc-contract.test.mjs",
+    "scripts/expected-manifest.config.mjs",
+    "src/entrypoints/background/background.ts",
+    "src/entrypoints/content/sample.tsx",
+    "src/entrypoints/options/options.tsx",
+    "src/entrypoints/popup/popup.tsx",
+    "src/lib/messaging/messages.ts",
+    "src/lib/storage/schema.ts"
+  ],
+  "commands": [
+    "build",
+    "check-type",
+    "dev",
+    "e2e",
+    "format",
+    "lint",
+    "package",
+    "render:icons",
+    "test",
+    "verify",
+    "verify:full",
+    "verify:manifest",
+    "zip"
+  ]
+}
+```
+
+<!-- AGENTS:DERIVATION-METADATA:END -->
+
 Chrome extension (Manifest V3) template built with Vite + TypeScript + React.
 Surfaces: popup, options page, background service worker, content script — each lives
-under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options) load
-`src/entrypoints/<surface>/<surface>.tsx`; the manifest is generated from
+under `src/entrypoints/`. Root-level HTML files load the popup and options
+entrypoints; the manifest is generated from
 `manifest.config.ts` via `@crxjs/vite-plugin`; `npm run build` outputs to
 `extension/` (gitignored). `src/lib/` holds shared modules entrypoints may import
 (never the reverse); `src/examples/` holds deletable sample code. See README's
@@ -87,21 +126,21 @@ under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options) load
 
 ## Commands
 
-| Command                | What it does                                                  | Notes                                                                              |
-| ---------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `npm ci`               | Install deps                                                  | installs exactly from `package-lock.json`                                          |
-| `npm run dev`          | Vite dev server with HMR                                      | via `@crxjs/vite-plugin`                                                           |
-| `npm run build`        | Build to `extension/`                                         | deletes and recreates the dir                                                      |
-| `npm run package`      | Build, verify manifest, create reproducible `extension.zip`   | archives distributable files from `extension/`                                     |
-| `npm run verify`       | check-type → lint → test → build → verify:manifest, in series | the safety contract for most changes; excludes e2e for speed                       |
-| `npm run verify:full`  | `verify` then `npm run e2e`                                   | full contract; requires installed Chromium                                         |
-| `npm run e2e`          | Run Playwright Chromium smoke tests                           | requires a prior build and installed Chromium                                      |
-| `npm run render:icons` | Render 16/48/128 px normal/dev PNG icons from SVG sources     | requires installed Chromium                                                        |
-| `npm run check-type`   | `tsc --noEmit`                                                |                                                                                    |
-| `npm test`             | Run Vitest                                                    | src tests use jsdom; script and e2e helper tests use Node                          |
-| `npm run lint`         | `oxlint` (check-only)                                         | no file mutation; pre-commit runs the staged-only equivalent via lint-staged       |
-| `npm run format`       | `prettier --write`                                            | rewrites files on disk; pre-commit runs the staged-only equivalent via lint-staged |
-| `npm run zip`          | Alias for `npm run package`                                   |                                                                                    |
+| Command | What it does | Notes |
+| --- | --- | --- |
+| `npm ci` | Install deps | installs exactly from `package-lock.json` |
+| `npm run dev` | Vite dev server with HMR | via `@crxjs/vite-plugin` |
+| `npm run build` | Build to `extension/` | deletes and recreates the dir |
+| `npm run package` | Build, verify manifest, create reproducible `extension.zip` | archives distributable files from `extension/` |
+| `npm run verify` | check-type → lint → test → build → verify:manifest, in series | the safety contract for most changes; excludes e2e for speed |
+| `npm run verify:full` | `verify` then `npm run e2e` | full contract; requires installed Chromium |
+| `npm run e2e` | Run Playwright Chromium smoke tests | requires a prior build and installed Chromium |
+| `npm run render:icons` | Render 16/48/128 px normal/dev PNG icons from SVG sources | requires installed Chromium |
+| `npm run check-type` | `tsc --noEmit` | |
+| `npm test` | Run Vitest | src tests use jsdom; script and e2e helper tests use Node |
+| `npm run lint` | `oxlint` (check-only) | no file mutation; pre-commit runs the staged-only equivalent via lint-staged |
+| `npm run format` | `prettier --write` | rewrites files on disk; pre-commit runs the staged-only equivalent via lint-staged |
+| `npm run zip` | Alias for `npm run package` | |
 
 `.nvmrc` pins Node 24, matching the `engines.node` (`>=24.0.0`) requirement.
 
@@ -112,11 +151,11 @@ under `src/entrypoints/<surface>/`. Root-level HTML files (popup/options) load
   `extension/manifest.json`, so build always runs first.
 - `npm run verify:full` runs `verify` and the real-Chromium E2E suite.
 
-| Change                                                                       | Run                                     |
-| ---------------------------------------------------------------------------- | --------------------------------------- |
-| `src/lib/**`, types, unit tests, `src/examples/**`, agent-document contracts | `npm run verify`                        |
-| `manifest.config.ts`, permissions, CSP                                       | `npm run verify` (asserts the manifest) |
-| entrypoint wiring, messaging/storage round-trips, anything E2E exercises     | `npm run verify:full`                   |
+| Change | Run |
+| --- | --- |
+| `src/lib/**`, types, unit tests, `src/examples/**`, agent-document contracts | `npm run verify` |
+| `manifest.config.ts`, permissions, CSP | `npm run verify` (asserts the manifest) |
+| entrypoint wiring, messaging/storage round-trips, anything E2E exercises | `npm run verify:full` |
 
 CI already runs the same underlying checks as separate jobs.
 
@@ -149,8 +188,8 @@ Minimal, real code paths for common changes:
   predicates; no runtime schema dependency). Register the handler in
   `src/entrypoints/background/background.ts` under `addMessageListeners({ ... })`,
   and send from a surface with `sendMessage(name, payload)`. The generic engine in
-  `createMessaging.ts` needs no change. Run `npm run verify:full` because only the
-  real-Chromium E2E exercises the round-trip.
+  `src/lib/messaging/createMessaging.ts` needs no change. Run
+  `npm run verify:full` because only the real-Chromium E2E exercises the round-trip.
 - **Add a storage key.** Add the key to `AppStorageValues` and `storageSchema` in
   `src/lib/storage/schema.ts` (`area` plus `defaultValue`). Generic accessors and
   `useStorageValue` follow automatically. Run `npm run verify`; use `verify:full`
@@ -179,13 +218,13 @@ Do not make these without explicit owner sign-off:
 
 Read these only when the row matches the task:
 
-| When you are...                                                                                                          | Read                                     |
-| ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| editing any `.ts`/`.tsx` file                                                                                            | `.claude/rules/typescript-react.md`      |
-| touching `manifest.config.ts`, background, or content scripts                                                            | `.claude/rules/chrome-extension.md`      |
-| writing tests                                                                                                            | `.claude/rules/testing.md`               |
-| adding an extension surface (popup/options/background/content script)                                                    | `.claude/skills/add-entrypoint/SKILL.md` |
+| When you are... | Read |
+| --- | --- |
+| editing any `.ts`/`.tsx` file | `.claude/rules/typescript-react.md` |
+| touching `manifest.config.ts`, background, or content scripts | `.claude/rules/chrome-extension.md` |
+| writing tests | `.claude/rules/testing.md` |
+| adding an extension surface (popup/options/background/content script) | `.claude/skills/add-entrypoint/SKILL.md` |
 | pruning surfaces, setting product identity, or auditing inherited docs while turning this template into a real extension | `.claude/skills/adapt-template/SKILL.md` |
-| releasing/packaging/deploying                                                                                            | `.claude/skills/release/SKILL.md`        |
+| releasing/packaging/deploying | `.claude/skills/release/SKILL.md` |
 
 <!-- AGENTS:DERIVATION-REQUIRED:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ narration. Point out problems bluntly.
 
 ```json
 {
+  "entrypointRoot": "src/entrypoints",
+  "sharedRoot": "src/lib",
   "surfaces": ["background", "content", "options", "popup"],
   "sharedLayers": ["messaging", "storage", "testing"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,11 @@
 
 @AGENTS.md
 
-Claude Code only: skills (`.claude/skills/`) and rules (`.claude/rules/`) are auto-discovered; the on-demand index in AGENTS.md exists for agents without auto-discovery (e.g. Codex).
+`AGENTS.md` is the single source of truth. The import above loads both its universal
+and derivation-required sections. When deriving a product, follow
+`.claude/skills/adapt-template/SKILL.md` to update the derivation-required section
+without duplicating instructions here.
+
+Claude Code only: skills (`.claude/skills/`) and rules (`.claude/rules/`) are
+auto-discovered; the on-demand index in `AGENTS.md` exists for agents without
+auto-discovery (e.g. Codex).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Claude Code Instructions
 
+<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->
+
 @AGENTS.md
 
 `AGENTS.md` is the single source of truth. The import above loads both its universal

--- a/scripts/agent-doc-contract.mjs
+++ b/scripts/agent-doc-contract.mjs
@@ -19,13 +19,21 @@ const ROOT_PATH_EXTENSION =
   /^(?:[^./][^/]*|\.[^./][^/]*)\.(?:html|json|md|mjs|svg|ts|tsx|yaml|yml)$/u;
 const ROOT_DOTFILES = new Set(['.nvmrc']);
 const IGNORED_DIRECTORIES = new Set([
+  '.cache',
   '.git',
+  '.next',
+  '.nuxt',
+  '.serverless',
   'coverage',
+  'dist',
   'extension',
+  'logs',
   'node_modules',
   'playwright-report',
   'test-results',
 ]);
+const IGNORED_FILES = new Set(['.env', '.env.test', 'extension.zip']);
+const IGNORED_FILE_PATTERNS = [/\.log$/u, /\.pid$/u, /\.tgz$/u];
 
 export const collectRepositoryEntries = (root) => {
   const entries = [];
@@ -38,6 +46,12 @@ export const collectRepositoryEntries = (root) => {
       if (entry.isDirectory()) {
         visit(absolutePath);
       } else if (entry.isFile()) {
+        if (
+          IGNORED_FILES.has(entry.name) ||
+          IGNORED_FILE_PATTERNS.some((pattern) => pattern.test(entry.name))
+        ) {
+          continue;
+        }
         entries.push(relative(root, absolutePath).replaceAll('\\', '/'));
       }
     }
@@ -81,16 +95,15 @@ const pathExists = (path, repositoryEntries) => {
 const extractCodeSpans = (text) =>
   [...text.matchAll(/`([^`\n]+)`/gu)].map((match) => match[1].trim());
 
-const isLiteralTrackedPath = (value, repositoryEntries) => {
+const isLiteralRepositoryPath = (value, repositoryEntries) => {
   if (
+    /\s/u.test(value) ||
     value.includes('*') ||
     value.includes('<') ||
     value.includes('>') ||
     value.includes('{') ||
     value.includes('}') ||
     value.startsWith('@') ||
-    value.startsWith('npm ') ||
-    value.startsWith('npx ') ||
     value.includes('://') ||
     value.startsWith('extension/') ||
     value === 'extension.zip'
@@ -155,6 +168,30 @@ const validateStringArray = (metadata, key, errors) => {
   }
 
   return [...new Set(value)].toSorted();
+};
+
+const validateRoot = (
+  metadata,
+  key,
+  label,
+  errors,
+  { nullable = false } = {},
+) => {
+  const value = metadata?.[key];
+
+  if (nullable && value === null) return null;
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push(
+      `Derivation metadata ${key} must be ${nullable ? 'a repository path or null' : 'a repository path'}.`,
+    );
+    return null;
+  }
+
+  if (value.endsWith('/')) {
+    errors.push(`Derivation metadata ${key} must not end with a slash.`);
+  }
+
+  return { label, path: value.replace(/\/$/u, '') };
 };
 
 const listDirectories = (repositoryEntries, root) =>
@@ -228,14 +265,33 @@ export const validateAgentDocContract = ({
     const metadata = parseMetadata(derivation, errors);
 
     if (metadata) {
-      const surfaces = validateStringArray(metadata, 'surfaces', errors);
-      const expectedSurfaces = listDirectories(
-        repositoryEntries,
-        'src/entrypoints',
+      const entrypointRoot = validateRoot(
+        metadata,
+        'entrypointRoot',
+        'Entrypoint',
+        errors,
       );
+      const sharedRoot = validateRoot(
+        metadata,
+        'sharedRoot',
+        'Shared',
+        errors,
+        { nullable: true },
+      );
+
+      for (const root of [entrypointRoot, sharedRoot].filter(Boolean)) {
+        if (!pathExists(root.path, repositoryEntries)) {
+          errors.push(`${root.label} root does not exist: ${root.path}`);
+        }
+      }
+
+      const surfaces = validateStringArray(metadata, 'surfaces', errors);
+      const expectedSurfaces = entrypointRoot
+        ? listDirectories(repositoryEntries, entrypointRoot.path)
+        : [];
       if (formatList(surfaces) !== formatList(expectedSurfaces)) {
         errors.push(
-          `Surface metadata must match src/entrypoints/: expected ${formatList(expectedSurfaces)}; received ${formatList(surfaces)}.`,
+          `Surface metadata must match ${entrypointRoot?.path ?? 'the configured entrypoint root'}/: expected ${formatList(expectedSurfaces)}; received ${formatList(surfaces)}.`,
         );
       }
 
@@ -244,25 +300,30 @@ export const validateAgentDocContract = ({
         'sharedLayers',
         errors,
       );
-      const expectedSharedLayers = listDirectories(
-        repositoryEntries,
-        'src/lib',
-      );
+      const expectedSharedLayers = sharedRoot
+        ? listDirectories(repositoryEntries, sharedRoot.path)
+        : [];
       if (formatList(sharedLayers) !== formatList(expectedSharedLayers)) {
         errors.push(
-          `Shared-layer metadata must match src/lib/: expected ${formatList(expectedSharedLayers)}; received ${formatList(sharedLayers)}.`,
+          `Shared-layer metadata must match ${sharedRoot?.path ?? 'the configured shared root'}/: expected ${formatList(expectedSharedLayers)}; received ${formatList(sharedLayers)}.`,
         );
       }
 
       const metadataKeys = Object.keys(metadata).toSorted();
-      if (formatList(metadataKeys) !== 'sharedLayers, surfaces') {
+      if (
+        formatList(metadataKeys) !==
+        'entrypointRoot, sharedLayers, sharedRoot, surfaces'
+      ) {
         errors.push(
-          'Derivation metadata must contain only surfaces and sharedLayers.',
+          'Derivation metadata must contain only entrypointRoot, sharedRoot, surfaces, and sharedLayers.',
         );
       }
     }
 
-    if (!derivation.includes('.claude/skills/adapt-template/SKILL.md')) {
+    if (
+      skill != null &&
+      !derivation.includes('.claude/skills/adapt-template/SKILL.md')
+    ) {
       errors.push(
         'Derivation-required section must reference .claude/skills/adapt-template/SKILL.md.',
       );
@@ -270,7 +331,7 @@ export const validateAgentDocContract = ({
 
     const codeSpans = extractCodeSpans(derivation);
     for (const path of codeSpans.filter((value) =>
-      isLiteralTrackedPath(value, repositoryEntries),
+      isLiteralRepositoryPath(value, repositoryEntries),
     )) {
       if (!pathExists(path, repositoryEntries)) {
         errors.push(`Referenced path does not exist: ${path}`);
@@ -283,15 +344,17 @@ export const validateAgentDocContract = ({
     }
   }
 
-  if (countOccurrences(skill, SKILL_UNIVERSAL_ANCHOR) !== 1) {
-    errors.push(
-      'adapt-template must declare the universal preservation contract.',
-    );
-  }
-  if (countOccurrences(skill, SKILL_DERIVATION_ANCHOR) !== 1) {
-    errors.push(
-      'adapt-template must declare the derivation synchronization contract.',
-    );
+  if (skill != null) {
+    if (countOccurrences(skill, SKILL_UNIVERSAL_ANCHOR) !== 1) {
+      errors.push(
+        'adapt-template must declare the universal preservation contract.',
+      );
+    }
+    if (countOccurrences(skill, SKILL_DERIVATION_ANCHOR) !== 1) {
+      errors.push(
+        'adapt-template must declare the derivation synchronization contract.',
+      );
+    }
   }
 
   const imports = claude.match(/^@AGENTS\.md\s*$/gmu) ?? [];

--- a/scripts/agent-doc-contract.mjs
+++ b/scripts/agent-doc-contract.mjs
@@ -1,0 +1,297 @@
+import { createHash } from 'node:crypto';
+
+export const UNIVERSAL_BEGIN = '<!-- AGENTS:UNIVERSAL:BEGIN -->';
+export const UNIVERSAL_END = '<!-- AGENTS:UNIVERSAL:END -->';
+export const DERIVATION_BEGIN = '<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->';
+export const DERIVATION_END = '<!-- AGENTS:DERIVATION-REQUIRED:END -->';
+
+const METADATA_BEGIN = '<!-- AGENTS:DERIVATION-METADATA:BEGIN -->';
+const METADATA_END = '<!-- AGENTS:DERIVATION-METADATA:END -->';
+const UNIVERSAL_CONTRACT_SHA256 =
+  '25c89ee3593c6b6ce74d3ad51e23d22c479b9e84542af1e74a1b746296474d9f';
+const SKILL_UNIVERSAL_ANCHOR = '<!-- AGENTS-CONTRACT:UNIVERSAL:PRESERVE -->';
+const SKILL_DERIVATION_ANCHOR =
+  '<!-- AGENTS-CONTRACT:DERIVATION:SYNCHRONIZE -->';
+const CLAUDE_SINGLE_SOURCE_ANCHOR = '<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->';
+const KNOWN_SURFACES = ['background', 'content', 'options', 'popup'];
+const KNOWN_SHARED_LAYERS = ['messaging', 'storage', 'testing'];
+const ROOT_PATH_EXTENSION =
+  /^(?:[^./][^/]*|\.[^./][^/]*)\.(?:html|json|md|mjs|svg|ts|tsx|yaml|yml)$/u;
+const ROOT_DOTFILES = new Set(['.nvmrc']);
+
+const countOccurrences = (text, value) => text.split(value).length - 1;
+
+const extractSection = (text, begin, end, label, errors) => {
+  const beginCount = countOccurrences(text, begin);
+  const endCount = countOccurrences(text, end);
+
+  if (beginCount !== 1 || endCount !== 1) {
+    errors.push(`${label} markers must each appear exactly once.`);
+    return null;
+  }
+
+  const beginIndex = text.indexOf(begin);
+  const endIndex = text.indexOf(end);
+
+  if (beginIndex >= endIndex) {
+    errors.push(`${label} markers are out of order.`);
+    return null;
+  }
+
+  return text.slice(beginIndex + begin.length, endIndex).trim();
+};
+
+const pathExists = (path, repositoryEntries) => {
+  const normalized = path.replace(/\/$/u, '');
+
+  return (
+    repositoryEntries.includes(normalized) ||
+    repositoryEntries.some((entry) => entry.startsWith(`${normalized}/`))
+  );
+};
+
+const extractCodeSpans = (text) =>
+  [...text.matchAll(/`([^`\n]+)`/gu)].map((match) => match[1].trim());
+
+const isLiteralTrackedPath = (value, repositoryEntries) => {
+  if (
+    value.includes('*') ||
+    value.includes('<') ||
+    value.includes('>') ||
+    value.includes('{') ||
+    value.includes('}') ||
+    value.startsWith('@') ||
+    value.includes('://') ||
+    value.startsWith('extension/') ||
+    value === 'extension.zip'
+  ) {
+    return false;
+  }
+
+  return (
+    value.includes('/') ||
+    repositoryEntries.includes(value) ||
+    ROOT_DOTFILES.has(value) ||
+    ROOT_PATH_EXTENSION.test(value)
+  );
+};
+
+const validateNpmCommand = (command, packageJson, errors) => {
+  if (command === 'npm ci' || command.startsWith('npm install ')) return;
+
+  const runMatch = command.match(/^npm run ([^\s]+)/u);
+  const directMatch = command.match(/^npm (test|start|stop|restart)(?:\s|$)/u);
+  const script = runMatch?.[1] ?? directMatch?.[1];
+
+  if (script && !Object.hasOwn(packageJson.scripts ?? {}, script)) {
+    errors.push(`Referenced npm script does not exist: ${script}`);
+  }
+};
+
+const parseMetadata = (derivation, errors) => {
+  const metadataSection = extractSection(
+    derivation,
+    METADATA_BEGIN,
+    METADATA_END,
+    'Derivation metadata',
+    errors,
+  );
+
+  if (metadataSection === null) return null;
+
+  const match = metadataSection.match(/^```json\s*([\s\S]*?)\s*```$/u);
+  if (!match) {
+    errors.push('Derivation metadata must be a fenced JSON object.');
+    return null;
+  }
+
+  try {
+    return JSON.parse(match[1]);
+  } catch (error) {
+    errors.push(`Derivation metadata is invalid JSON: ${error.message}`);
+    return null;
+  }
+};
+
+const validateStringArray = (metadata, key, errors) => {
+  const value = metadata?.[key];
+
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => typeof item !== 'string' || item.length === 0)
+  ) {
+    errors.push(`Derivation metadata ${key} must be an array of strings.`);
+    return [];
+  }
+
+  return [...new Set(value)].toSorted();
+};
+
+const listDirectories = (repositoryEntries, root) =>
+  [
+    ...new Set(
+      repositoryEntries
+        .filter((entry) => entry.startsWith(`${root}/`))
+        .map((entry) => entry.slice(root.length + 1))
+        .filter((entry) => entry.includes('/'))
+        .map((entry) => entry.split('/')[0]),
+    ),
+  ].toSorted();
+
+const formatList = (items) => items.join(', ');
+
+export const validateAgentDocContract = ({
+  agents,
+  claude,
+  packageJson,
+  repositoryEntries,
+  skill,
+}) => {
+  const errors = [];
+  const universal = extractSection(
+    agents,
+    UNIVERSAL_BEGIN,
+    UNIVERSAL_END,
+    'Universal section',
+    errors,
+  );
+  const derivation = extractSection(
+    agents,
+    DERIVATION_BEGIN,
+    DERIVATION_END,
+    'Derivation-required section',
+    errors,
+  );
+
+  const markerOffsets = [
+    agents.indexOf(UNIVERSAL_BEGIN),
+    agents.indexOf(UNIVERSAL_END),
+    agents.indexOf(DERIVATION_BEGIN),
+    agents.indexOf(DERIVATION_END),
+  ];
+  if (
+    markerOffsets.every((offset) => offset >= 0) &&
+    markerOffsets.some(
+      (offset, index) => index > 0 && offset <= markerOffsets[index - 1],
+    )
+  ) {
+    errors.push(
+      'Universal and derivation-required sections must be ordered and non-overlapping.',
+    );
+  }
+
+  if (universal === '') errors.push('Universal section must not be empty.');
+  if (derivation === '') {
+    errors.push('Derivation-required section must not be empty.');
+  }
+
+  if (universal !== null && universal !== '') {
+    const hash = createHash('sha256').update(universal).digest('hex');
+    if (hash !== UNIVERSAL_CONTRACT_SHA256) {
+      errors.push(
+        'Universal section content differs from the canonical contract.',
+      );
+    }
+  }
+
+  if (derivation !== null && derivation !== '') {
+    const metadata = parseMetadata(derivation, errors);
+
+    if (metadata) {
+      const surfaces = validateStringArray(metadata, 'surfaces', errors);
+      const expectedSurfaces = listDirectories(
+        repositoryEntries,
+        'src/entrypoints',
+      );
+      if (formatList(surfaces) !== formatList(expectedSurfaces)) {
+        errors.push(
+          `Surface metadata must match src/entrypoints/: expected ${formatList(expectedSurfaces)}; received ${formatList(surfaces)}.`,
+        );
+      }
+
+      const sharedLayers = validateStringArray(
+        metadata,
+        'sharedLayers',
+        errors,
+      );
+      const expectedSharedLayers = listDirectories(
+        repositoryEntries,
+        'src/lib',
+      );
+      if (formatList(sharedLayers) !== formatList(expectedSharedLayers)) {
+        errors.push(
+          `Shared-layer metadata must match src/lib/: expected ${formatList(expectedSharedLayers)}; received ${formatList(sharedLayers)}.`,
+        );
+      }
+
+      for (const path of validateStringArray(metadata, 'paths', errors)) {
+        if (!pathExists(path, repositoryEntries)) {
+          errors.push(`Metadata path does not exist: ${path}`);
+        }
+      }
+
+      for (const command of validateStringArray(metadata, 'commands', errors)) {
+        if (!Object.hasOwn(packageJson.scripts ?? {}, command)) {
+          errors.push(`Metadata npm script does not exist: ${command}`);
+        }
+      }
+
+      for (const surface of KNOWN_SURFACES.filter(
+        (surface) => !surfaces.includes(surface),
+      )) {
+        if (new RegExp(`\\b${surface}\\b`, 'iu').test(derivation)) {
+          errors.push(
+            `Derivation-required prose mentions removed surface: ${surface}`,
+          );
+        }
+      }
+
+      for (const layer of KNOWN_SHARED_LAYERS.filter(
+        (layer) => !sharedLayers.includes(layer),
+      )) {
+        if (new RegExp(`\\b${layer}\\b`, 'iu').test(derivation)) {
+          errors.push(
+            `Derivation-required prose mentions removed shared layer: ${layer}`,
+          );
+        }
+      }
+    }
+
+    const codeSpans = extractCodeSpans(derivation);
+    for (const path of codeSpans.filter((value) =>
+      isLiteralTrackedPath(value, repositoryEntries),
+    )) {
+      if (!pathExists(path, repositoryEntries)) {
+        errors.push(`Referenced path does not exist: ${path}`);
+      }
+    }
+    for (const command of codeSpans.filter((value) =>
+      value.startsWith('npm '),
+    )) {
+      validateNpmCommand(command, packageJson, errors);
+    }
+  }
+
+  if (countOccurrences(skill, SKILL_UNIVERSAL_ANCHOR) !== 1) {
+    errors.push(
+      'adapt-template must declare the universal preservation contract.',
+    );
+  }
+  if (countOccurrences(skill, SKILL_DERIVATION_ANCHOR) !== 1) {
+    errors.push(
+      'adapt-template must declare the derivation synchronization contract.',
+    );
+  }
+
+  const imports = claude.match(/^@AGENTS\.md\s*$/gmu) ?? [];
+  if (imports.length !== 1) {
+    errors.push('CLAUDE.md must import AGENTS.md exactly once.');
+  }
+  if (countOccurrences(claude, CLAUDE_SINGLE_SOURCE_ANCHOR) !== 1) {
+    errors.push(
+      'CLAUDE.md must declare AGENTS.md as its single source of truth.',
+    );
+  }
+
+  return [...new Set(errors)];
+};

--- a/scripts/agent-doc-contract.mjs
+++ b/scripts/agent-doc-contract.mjs
@@ -1,4 +1,6 @@
 import { createHash } from 'node:crypto';
+import { readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
 
 export const UNIVERSAL_BEGIN = '<!-- AGENTS:UNIVERSAL:BEGIN -->';
 export const UNIVERSAL_END = '<!-- AGENTS:UNIVERSAL:END -->';
@@ -8,16 +10,42 @@ export const DERIVATION_END = '<!-- AGENTS:DERIVATION-REQUIRED:END -->';
 const METADATA_BEGIN = '<!-- AGENTS:DERIVATION-METADATA:BEGIN -->';
 const METADATA_END = '<!-- AGENTS:DERIVATION-METADATA:END -->';
 const UNIVERSAL_CONTRACT_SHA256 =
-  '25c89ee3593c6b6ce74d3ad51e23d22c479b9e84542af1e74a1b746296474d9f';
+  '7d635887805d369d092a4bebacc2b836cd42901b40108bc956eacb83d35c2ff7';
 const SKILL_UNIVERSAL_ANCHOR = '<!-- AGENTS-CONTRACT:UNIVERSAL:PRESERVE -->';
 const SKILL_DERIVATION_ANCHOR =
   '<!-- AGENTS-CONTRACT:DERIVATION:SYNCHRONIZE -->';
 const CLAUDE_SINGLE_SOURCE_ANCHOR = '<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->';
-const KNOWN_SURFACES = ['background', 'content', 'options', 'popup'];
-const KNOWN_SHARED_LAYERS = ['messaging', 'storage', 'testing'];
 const ROOT_PATH_EXTENSION =
   /^(?:[^./][^/]*|\.[^./][^/]*)\.(?:html|json|md|mjs|svg|ts|tsx|yaml|yml)$/u;
 const ROOT_DOTFILES = new Set(['.nvmrc']);
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  'coverage',
+  'extension',
+  'node_modules',
+  'playwright-report',
+  'test-results',
+]);
+
+export const collectRepositoryEntries = (root) => {
+  const entries = [];
+
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
+
+      const absolutePath = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+      } else if (entry.isFile()) {
+        entries.push(relative(root, absolutePath).replaceAll('\\', '/'));
+      }
+    }
+  };
+
+  visit(root);
+  return entries.toSorted();
+};
 
 const countOccurrences = (text, value) => text.split(value).length - 1;
 
@@ -61,6 +89,8 @@ const isLiteralTrackedPath = (value, repositoryEntries) => {
     value.includes('{') ||
     value.includes('}') ||
     value.startsWith('@') ||
+    value.startsWith('npm ') ||
+    value.startsWith('npx ') ||
     value.includes('://') ||
     value.startsWith('extension/') ||
     value === 'extension.zip'
@@ -189,7 +219,7 @@ export const validateAgentDocContract = ({
     const hash = createHash('sha256').update(universal).digest('hex');
     if (hash !== UNIVERSAL_CONTRACT_SHA256) {
       errors.push(
-        'Universal section content differs from the canonical contract.',
+        `Universal section content differs from the canonical contract: expected SHA-256 ${UNIVERSAL_CONTRACT_SHA256}; received ${hash}. Hash the trimmed text between the universal markers after an intentional contract update.`,
       );
     }
   }
@@ -224,37 +254,18 @@ export const validateAgentDocContract = ({
         );
       }
 
-      for (const path of validateStringArray(metadata, 'paths', errors)) {
-        if (!pathExists(path, repositoryEntries)) {
-          errors.push(`Metadata path does not exist: ${path}`);
-        }
+      const metadataKeys = Object.keys(metadata).toSorted();
+      if (formatList(metadataKeys) !== 'sharedLayers, surfaces') {
+        errors.push(
+          'Derivation metadata must contain only surfaces and sharedLayers.',
+        );
       }
+    }
 
-      for (const command of validateStringArray(metadata, 'commands', errors)) {
-        if (!Object.hasOwn(packageJson.scripts ?? {}, command)) {
-          errors.push(`Metadata npm script does not exist: ${command}`);
-        }
-      }
-
-      for (const surface of KNOWN_SURFACES.filter(
-        (surface) => !surfaces.includes(surface),
-      )) {
-        if (new RegExp(`\\b${surface}\\b`, 'iu').test(derivation)) {
-          errors.push(
-            `Derivation-required prose mentions removed surface: ${surface}`,
-          );
-        }
-      }
-
-      for (const layer of KNOWN_SHARED_LAYERS.filter(
-        (layer) => !sharedLayers.includes(layer),
-      )) {
-        if (new RegExp(`\\b${layer}\\b`, 'iu').test(derivation)) {
-          errors.push(
-            `Derivation-required prose mentions removed shared layer: ${layer}`,
-          );
-        }
-      }
+    if (!derivation.includes('.claude/skills/adapt-template/SKILL.md')) {
+      errors.push(
+        'Derivation-required section must reference .claude/skills/adapt-template/SKILL.md.',
+      );
     }
 
     const codeSpans = extractCodeSpans(derivation);

--- a/scripts/agent-doc-contract.mjs
+++ b/scripts/agent-doc-contract.mjs
@@ -18,7 +18,7 @@ const CLAUDE_SINGLE_SOURCE_ANCHOR = '<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->';
 const ROOT_PATH_EXTENSION =
   /^(?:[^./][^/]*|\.[^./][^/]*)\.(?:html|json|md|mjs|svg|ts|tsx|yaml|yml)$/u;
 const ROOT_DOTFILES = new Set(['.nvmrc']);
-const IGNORED_DIRECTORIES = new Set([
+const ROOT_IGNORED_DIRECTORIES = new Set([
   '.cache',
   '.git',
   '.next',
@@ -32,23 +32,33 @@ const IGNORED_DIRECTORIES = new Set([
   'playwright-report',
   'test-results',
 ]);
-const IGNORED_FILES = new Set(['.env', '.env.test', 'extension.zip']);
-const IGNORED_FILE_PATTERNS = [/\.log$/u, /\.pid$/u, /\.tgz$/u];
+const ROOT_IGNORED_FILES = new Set(['.env', '.env.test', 'extension.zip']);
+const ROOT_IGNORED_FILE_PATTERNS = [/\.log$/u, /\.pid$/u, /\.tgz$/u];
 
 export const collectRepositoryEntries = (root) => {
   const entries = [];
 
   const visit = (directory) => {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
+      const isRootEntry = directory === root;
+      if (
+        isRootEntry &&
+        entry.isDirectory() &&
+        ROOT_IGNORED_DIRECTORIES.has(entry.name)
+      ) {
+        continue;
+      }
 
       const absolutePath = join(directory, entry.name);
       if (entry.isDirectory()) {
         visit(absolutePath);
       } else if (entry.isFile()) {
         if (
-          IGNORED_FILES.has(entry.name) ||
-          IGNORED_FILE_PATTERNS.some((pattern) => pattern.test(entry.name))
+          isRootEntry &&
+          (ROOT_IGNORED_FILES.has(entry.name) ||
+            ROOT_IGNORED_FILE_PATTERNS.some((pattern) =>
+              pattern.test(entry.name),
+            ))
         ) {
           continue;
         }
@@ -90,6 +100,12 @@ const pathExists = (path, repositoryEntries) => {
     repositoryEntries.includes(normalized) ||
     repositoryEntries.some((entry) => entry.startsWith(`${normalized}/`))
   );
+};
+
+const directoryExists = (path, repositoryEntries) => {
+  const normalized = path.replace(/\/$/u, '');
+
+  return repositoryEntries.some((entry) => entry.startsWith(`${normalized}/`));
 };
 
 const extractCodeSpans = (text) =>
@@ -282,6 +298,10 @@ export const validateAgentDocContract = ({
       for (const root of [entrypointRoot, sharedRoot].filter(Boolean)) {
         if (!pathExists(root.path, repositoryEntries)) {
           errors.push(`${root.label} root does not exist: ${root.path}`);
+        } else if (!directoryExists(root.path, repositoryEntries)) {
+          errors.push(
+            `${root.label} root is not a repository directory: ${root.path}`,
+          );
         }
       }
 

--- a/scripts/agent-doc-contract.mjs
+++ b/scripts/agent-doc-contract.mjs
@@ -18,9 +18,9 @@ const CLAUDE_SINGLE_SOURCE_ANCHOR = '<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->';
 const ROOT_PATH_EXTENSION =
   /^(?:[^./][^/]*|\.[^./][^/]*)\.(?:html|json|md|mjs|svg|ts|tsx|yaml|yml)$/u;
 const ROOT_DOTFILES = new Set(['.nvmrc']);
+const ALWAYS_IGNORED_DIRECTORIES = new Set(['.git', 'node_modules']);
 const ROOT_IGNORED_DIRECTORIES = new Set([
   '.cache',
-  '.git',
   '.next',
   '.nuxt',
   '.serverless',
@@ -28,7 +28,6 @@ const ROOT_IGNORED_DIRECTORIES = new Set([
   'dist',
   'extension',
   'logs',
-  'node_modules',
   'playwright-report',
   'test-results',
 ]);
@@ -42,9 +41,9 @@ export const collectRepositoryEntries = (root) => {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const isRootEntry = directory === root;
       if (
-        isRootEntry &&
         entry.isDirectory() &&
-        ROOT_IGNORED_DIRECTORIES.has(entry.name)
+        (ALWAYS_IGNORED_DIRECTORIES.has(entry.name) ||
+          (isRootEntry && ROOT_IGNORED_DIRECTORIES.has(entry.name)))
       ) {
         continue;
       }

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -1,23 +1,25 @@
 // @vitest-environment node
 
-import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   DERIVATION_BEGIN,
   DERIVATION_END,
+  collectRepositoryEntries,
   validateAgentDocContract,
 } from './agent-doc-contract.mjs';
 
 const readRepositoryFile = (path) => readFileSync(path, 'utf8');
 
-const repositoryEntries = execFileSync(
-  'git',
-  ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
-  { encoding: 'utf8' },
-)
-  .split('\0')
-  .filter((path) => path && existsSync(path));
+const repositoryEntries = collectRepositoryEntries(process.cwd());
 
 const validInput = {
   agents: readRepositoryFile('AGENTS.md'),
@@ -44,8 +46,23 @@ test('rejects changes to the canonical universal section', () => {
     '\n\nx\n\n',
   );
 
+  expect(validateAgentDocContract({ ...validInput, agents })).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(
+        /^Universal section content differs from the canonical contract: expected SHA-256 [a-f0-9]{64}; received [a-f0-9]{64}\./u,
+      ),
+    ]),
+  );
+});
+
+test('requires the derivation section to reference adapt-template', () => {
+  const agents = validInput.agents.replaceAll(
+    '.claude/skills/adapt-template/SKILL.md',
+    '.claude/skills/release/SKILL.md',
+  );
+
   expect(validateAgentDocContract({ ...validInput, agents })).toContain(
-    'Universal section content differs from the canonical contract.',
+    'Derivation-required section must reference .claude/skills/adapt-template/SKILL.md.',
   );
 });
 
@@ -82,6 +99,16 @@ test('rejects an npm command that package.json does not provide', () => {
   );
 });
 
+test('does not interpret an npm command containing a path as a file path', () => {
+  const agents = validInput.agents.replace(
+    DERIVATION_END,
+    'Run `npm test -- --run scripts/agent-doc-contract.test.mjs`.\n\n' +
+      DERIVATION_END,
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toEqual([]);
+});
+
 test('rejects surface metadata that no longer matches the entrypoint tree', () => {
   const agents = validInput.agents.replace('"background", ', '');
 
@@ -90,21 +117,15 @@ test('rejects surface metadata that no longer matches the entrypoint tree', () =
   );
 });
 
-test('rejects stale surface prose after that surface is removed', () => {
-  const agents = validInput.agents
-    .replace('"background", ', '')
-    .replace('    "src/entrypoints/background/background.ts",\n', '');
-  const entriesWithoutBackground = validInput.repositoryEntries.filter(
-    (path) => !path.startsWith('src/entrypoints/background/'),
+test('rejects metadata keys that duplicate prose validation', () => {
+  const agents = validInput.agents.replace(
+    '"sharedLayers": ["messaging", "storage", "testing"]',
+    '"sharedLayers": ["messaging", "storage", "testing"], "paths": ["AGENTS.md"]',
   );
 
-  expect(
-    validateAgentDocContract({
-      ...validInput,
-      agents,
-      repositoryEntries: entriesWithoutBackground,
-    }),
-  ).toContain('Derivation-required prose mentions removed surface: background');
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Derivation metadata must contain only surfaces and sharedLayers.',
+  );
 });
 
 test('rejects an instruction path after its target is deleted', () => {
@@ -115,6 +136,57 @@ test('rejects an instruction path after its target is deleted', () => {
   expect(
     validateAgentDocContract({ ...validInput, repositoryEntries }),
   ).toContain('Referenced path does not exist: .claude/rules/testing.md');
+});
+
+test('allows ordinary prose that uses removed surface or layer words', () => {
+  const universalBlock = validInput.agents.slice(
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:BEGIN -->'),
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:END -->') +
+      '<!-- AGENTS:UNIVERSAL:END -->'.length,
+  );
+  const derivation = `<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->
+
+<!-- AGENTS:DERIVATION-METADATA:BEGIN -->
+
+\`\`\`json
+{"surfaces":["content"],"sharedLayers":[]}
+\`\`\`
+
+<!-- AGENTS:DERIVATION-METADATA:END -->
+
+Follow \`.claude/skills/adapt-template/SKILL.md\`.
+CLI options are defined in \`vite.config.ts\`.
+The extension keeps no persistent storage. Unit testing stays in the fast lane.
+
+<!-- AGENTS:DERIVATION-REQUIRED:END -->`;
+
+  expect(
+    validateAgentDocContract({
+      ...validInput,
+      agents: `${universalBlock}\n\n${derivation}\n`,
+      repositoryEntries: [
+        '.claude/skills/adapt-template/SKILL.md',
+        'src/entrypoints/content/product.ts',
+        'vite.config.ts',
+      ],
+    }),
+  ).toEqual([]);
+});
+
+test('collects repository entries without requiring a git repository', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
+  try {
+    mkdirSync(join(root, 'src', 'entrypoints', 'content'), { recursive: true });
+    writeFileSync(join(root, 'AGENTS.md'), 'contract');
+    writeFileSync(join(root, 'src', 'entrypoints', 'content', 'index.ts'), '');
+
+    expect(collectRepositoryEntries(root)).toEqual([
+      'AGENTS.md',
+      'src/entrypoints/content/index.ts',
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('rejects empty or malformed boundary sections', () => {

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -18,6 +19,8 @@ import {
 } from './agent-doc-contract.mjs';
 
 const readRepositoryFile = (path) => readFileSync(path, 'utf8');
+const readOptionalRepositoryFile = (path) =>
+  existsSync(path) ? readRepositoryFile(path) : null;
 
 const repositoryEntries = collectRepositoryEntries(process.cwd());
 
@@ -26,7 +29,7 @@ const validInput = {
   claude: readRepositoryFile('CLAUDE.md'),
   packageJson: JSON.parse(readRepositoryFile('package.json')),
   repositoryEntries,
-  skill: readRepositoryFile('.claude/skills/adapt-template/SKILL.md'),
+  skill: readOptionalRepositoryFile('.claude/skills/adapt-template/SKILL.md'),
 };
 
 const replaceSection = (text, begin, end, replacement) => {
@@ -64,6 +67,25 @@ test('requires the derivation section to reference adapt-template', () => {
   expect(validateAgentDocContract({ ...validInput, agents })).toContain(
     'Derivation-required section must reference .claude/skills/adapt-template/SKILL.md.',
   );
+});
+
+test('allows a derived product to remove adapt-template and its reference', () => {
+  const agents = validInput.agents.replaceAll(
+    '.claude/skills/adapt-template/SKILL.md',
+    '.claude/skills/release/SKILL.md',
+  );
+  const repositoryEntries = validInput.repositoryEntries.filter(
+    (path) => path !== '.claude/skills/adapt-template/SKILL.md',
+  );
+
+  expect(
+    validateAgentDocContract({
+      ...validInput,
+      agents,
+      repositoryEntries,
+      skill: null,
+    }),
+  ).toEqual([]);
 });
 
 test('rejects a stale path in the derivation-required section', () => {
@@ -109,6 +131,15 @@ test('does not interpret an npm command containing a path as a file path', () =>
   expect(validateAgentDocContract({ ...validInput, agents })).toEqual([]);
 });
 
+test('does not interpret other commands containing paths as file paths', () => {
+  const agents = validInput.agents.replace(
+    DERIVATION_END,
+    'Run `node scripts/verify-manifest.mjs`.\n\n' + DERIVATION_END,
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toEqual([]);
+});
+
 test('rejects surface metadata that no longer matches the entrypoint tree', () => {
   const agents = validInput.agents.replace('"background", ', '');
 
@@ -124,7 +155,7 @@ test('rejects metadata keys that duplicate prose validation', () => {
   );
 
   expect(validateAgentDocContract({ ...validInput, agents })).toContain(
-    'Derivation metadata must contain only surfaces and sharedLayers.',
+    'Derivation metadata must contain only entrypointRoot, sharedRoot, surfaces, and sharedLayers.',
   );
 });
 
@@ -149,7 +180,7 @@ test('allows ordinary prose that uses removed surface or layer words', () => {
 <!-- AGENTS:DERIVATION-METADATA:BEGIN -->
 
 \`\`\`json
-{"surfaces":["content"],"sharedLayers":[]}
+{"entrypointRoot":"src/entrypoints","sharedRoot":null,"surfaces":["content"],"sharedLayers":[]}
 \`\`\`
 
 <!-- AGENTS:DERIVATION-METADATA:END -->
@@ -173,6 +204,60 @@ The extension keeps no persistent storage. Unit testing stays in the fast lane.
   ).toEqual([]);
 });
 
+test('uses metadata roots when a derived product changes its source layout', () => {
+  const universalBlock = validInput.agents.slice(
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:BEGIN -->'),
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:END -->') +
+      '<!-- AGENTS:UNIVERSAL:END -->'.length,
+  );
+  const derivation = `<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->
+
+<!-- AGENTS:DERIVATION-METADATA:BEGIN -->
+
+\`\`\`json
+{
+  "entrypointRoot": "src/surfaces",
+  "sharedRoot": "src/shared",
+  "surfaces": ["content"],
+  "sharedLayers": ["core"]
+}
+\`\`\`
+
+<!-- AGENTS:DERIVATION-METADATA:END -->
+
+Follow \`.claude/skills/adapt-template/SKILL.md\`.
+
+<!-- AGENTS:DERIVATION-REQUIRED:END -->`;
+
+  expect(
+    validateAgentDocContract({
+      ...validInput,
+      agents: `${universalBlock}\n\n${derivation}\n`,
+      repositoryEntries: [
+        '.claude/skills/adapt-template/SKILL.md',
+        'src/shared/core/index.ts',
+        'src/surfaces/content/product.ts',
+      ],
+    }),
+  ).toEqual([]);
+});
+
+test('rejects metadata roots that do not exist', () => {
+  const agents = validInput.agents
+    .replace(
+      '"entrypointRoot": "src/entrypoints"',
+      '"entrypointRoot": "src/missing-entrypoints"',
+    )
+    .replace('"sharedRoot": "src/lib"', '"sharedRoot": "src/missing-shared"');
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toEqual(
+    expect.arrayContaining([
+      'Entrypoint root does not exist: src/missing-entrypoints',
+      'Shared root does not exist: src/missing-shared',
+    ]),
+  );
+});
+
 test('collects repository entries without requiring a git repository', () => {
   const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
   try {
@@ -184,6 +269,19 @@ test('collects repository entries without requiring a git repository', () => {
       'AGENTS.md',
       'src/entrypoints/content/index.ts',
     ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('does not collect generated directories ignored by the repository', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
+  try {
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'AGENTS.md'), 'contract');
+    writeFileSync(join(root, 'dist', 'notes.md'), 'generated');
+
+    expect(collectRepositoryEntries(root)).toEqual(['AGENTS.md']);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -258,6 +258,22 @@ test('rejects metadata roots that do not exist', () => {
   );
 });
 
+test('rejects a metadata root that points to a file', () => {
+  const agents = validInput.agents
+    .replace(
+      '"entrypointRoot": "src/entrypoints"',
+      '"entrypointRoot": "AGENTS.md"',
+    )
+    .replace(
+      '"surfaces": ["background", "content", "options", "popup"]',
+      '"surfaces": []',
+    );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Entrypoint root is not a repository directory: AGENTS.md',
+  );
+});
+
 test('collects repository entries without requiring a git repository', () => {
   const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
   try {
@@ -282,6 +298,20 @@ test('does not collect generated directories ignored by the repository', () => {
     writeFileSync(join(root, 'dist', 'notes.md'), 'generated');
 
     expect(collectRepositoryEntries(root)).toEqual(['AGENTS.md']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('keeps source directories whose basename matches a root-level ignore', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
+  try {
+    mkdirSync(join(root, 'logs'), { recursive: true });
+    mkdirSync(join(root, 'src', 'lib', 'logs'), { recursive: true });
+    writeFileSync(join(root, 'logs', 'debug.log'), 'generated');
+    writeFileSync(join(root, 'src', 'lib', 'logs', 'logger.ts'), 'source');
+
+    expect(collectRepositoryEntries(root)).toEqual(['src/lib/logs/logger.ts']);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const UNIVERSAL_BEGIN = '<!-- AGENTS:UNIVERSAL:BEGIN -->';
+const UNIVERSAL_END = '<!-- AGENTS:UNIVERSAL:END -->';
+const DERIVATION_BEGIN = '<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->';
+const DERIVATION_END = '<!-- AGENTS:DERIVATION-REQUIRED:END -->';
+
+const readRepositoryFile = (path) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8');
+
+const countOccurrences = (text, value) => text.split(value).length - 1;
+
+const extractSection = (text, begin, end) => {
+  const beginIndex = text.indexOf(begin);
+  const endIndex = text.indexOf(end);
+
+  return text.slice(beginIndex + begin.length, endIndex).trim();
+};
+
+test('AGENTS.md has one ordered, non-empty pair of each contract boundary', () => {
+  const agents = readRepositoryFile('AGENTS.md');
+  const markers = [
+    UNIVERSAL_BEGIN,
+    UNIVERSAL_END,
+    DERIVATION_BEGIN,
+    DERIVATION_END,
+  ];
+
+  expect(markers.map((marker) => countOccurrences(agents, marker))).toEqual([
+    1, 1, 1, 1,
+  ]);
+  expect(markers.map((marker) => agents.indexOf(marker))).toEqual(
+    markers.map((marker) => agents.indexOf(marker)).toSorted((a, b) => a - b),
+  );
+  expect(extractSection(agents, UNIVERSAL_BEGIN, UNIVERSAL_END)).not.toBe('');
+  expect(extractSection(agents, DERIVATION_BEGIN, DERIVATION_END)).not.toBe('');
+});
+
+test('the derivation-required section points agents to adapt-template', () => {
+  const agents = readRepositoryFile('AGENTS.md');
+  const derivationSection = extractSection(
+    agents,
+    DERIVATION_BEGIN,
+    DERIVATION_END,
+  );
+
+  expect(derivationSection).toContain('.claude/skills/adapt-template/SKILL.md');
+});
+
+test('adapt-template preserves the universal boundary and updates the derivation boundary', () => {
+  const skill = readRepositoryFile('.claude/skills/adapt-template/SKILL.md');
+
+  expect(skill).toContain(UNIVERSAL_BEGIN);
+  expect(skill).toContain(UNIVERSAL_END);
+  expect(skill).toContain(DERIVATION_BEGIN);
+  expect(skill).toContain(DERIVATION_END);
+  expect(skill).toMatch(
+    /universal section[^.]+(?:preserve|do not (?:edit|rewrite))/i,
+  );
+  expect(skill).toMatch(
+    /derivation-required section[^.]+(?:update|rewrite|delete)/i,
+  );
+});
+
+test('CLAUDE.md imports AGENTS.md exactly once', () => {
+  const claude = readRepositoryFile('CLAUDE.md');
+  const imports = claude.match(/^@AGENTS\.md\s*$/gmu) ?? [];
+
+  expect(imports).toHaveLength(1);
+});

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -1,73 +1,178 @@
 // @vitest-environment node
 
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 
-const UNIVERSAL_BEGIN = '<!-- AGENTS:UNIVERSAL:BEGIN -->';
-const UNIVERSAL_END = '<!-- AGENTS:UNIVERSAL:END -->';
-const DERIVATION_BEGIN = '<!-- AGENTS:DERIVATION-REQUIRED:BEGIN -->';
-const DERIVATION_END = '<!-- AGENTS:DERIVATION-REQUIRED:END -->';
+import {
+  DERIVATION_BEGIN,
+  DERIVATION_END,
+  validateAgentDocContract,
+} from './agent-doc-contract.mjs';
 
-const readRepositoryFile = (path) =>
-  readFileSync(resolve(process.cwd(), path), 'utf8');
+const readRepositoryFile = (path) => readFileSync(path, 'utf8');
 
-const countOccurrences = (text, value) => text.split(value).length - 1;
+const repositoryEntries = execFileSync(
+  'git',
+  ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+  { encoding: 'utf8' },
+)
+  .split('\0')
+  .filter((path) => path && existsSync(path));
 
-const extractSection = (text, begin, end) => {
-  const beginIndex = text.indexOf(begin);
-  const endIndex = text.indexOf(end);
-
-  return text.slice(beginIndex + begin.length, endIndex).trim();
+const validInput = {
+  agents: readRepositoryFile('AGENTS.md'),
+  claude: readRepositoryFile('CLAUDE.md'),
+  packageJson: JSON.parse(readRepositoryFile('package.json')),
+  repositoryEntries,
+  skill: readRepositoryFile('.claude/skills/adapt-template/SKILL.md'),
 };
 
-test('AGENTS.md has one ordered, non-empty pair of each contract boundary', () => {
-  const agents = readRepositoryFile('AGENTS.md');
-  const markers = [
-    UNIVERSAL_BEGIN,
-    UNIVERSAL_END,
+const replaceSection = (text, begin, end, replacement) => {
+  const before = text.slice(0, text.indexOf(begin) + begin.length);
+  const after = text.slice(text.indexOf(end));
+
+  return `${before}\n\n${replacement}\n\n${after}`;
+};
+
+test('accepts the repository agent-document contract', () => {
+  expect(validateAgentDocContract(validInput)).toEqual([]);
+});
+
+test('rejects changes to the canonical universal section', () => {
+  const agents = validInput.agents.replace(
+    /(?<=<!-- AGENTS:UNIVERSAL:BEGIN -->)[\s\S]*?(?=<!-- AGENTS:UNIVERSAL:END -->)/u,
+    '\n\nx\n\n',
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Universal section content differs from the canonical contract.',
+  );
+});
+
+test('rejects a stale path in the derivation-required section', () => {
+  const agents = validInput.agents.replace(
+    DERIVATION_END,
+    'See `.claude/rules/deleted.md`.\n\n' + DERIVATION_END,
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Referenced path does not exist: .claude/rules/deleted.md',
+  );
+});
+
+test('rejects a stale root-document path', () => {
+  const agents = validInput.agents.replace(
+    DERIVATION_END,
+    'See `deleted.md`.\n\n' + DERIVATION_END,
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Referenced path does not exist: deleted.md',
+  );
+});
+
+test('rejects an npm command that package.json does not provide', () => {
+  const agents = validInput.agents.replace(
+    DERIVATION_END,
+    'Run `npm run deleted-script`.\n\n' + DERIVATION_END,
+  );
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Referenced npm script does not exist: deleted-script',
+  );
+});
+
+test('rejects surface metadata that no longer matches the entrypoint tree', () => {
+  const agents = validInput.agents.replace('"background", ', '');
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Surface metadata must match src/entrypoints/: expected background, content, options, popup; received content, options, popup.',
+  );
+});
+
+test('rejects stale surface prose after that surface is removed', () => {
+  const agents = validInput.agents
+    .replace('"background", ', '')
+    .replace('    "src/entrypoints/background/background.ts",\n', '');
+  const entriesWithoutBackground = validInput.repositoryEntries.filter(
+    (path) => !path.startsWith('src/entrypoints/background/'),
+  );
+
+  expect(
+    validateAgentDocContract({
+      ...validInput,
+      agents,
+      repositoryEntries: entriesWithoutBackground,
+    }),
+  ).toContain('Derivation-required prose mentions removed surface: background');
+});
+
+test('rejects an instruction path after its target is deleted', () => {
+  const repositoryEntries = validInput.repositoryEntries.filter(
+    (path) => path !== '.claude/rules/testing.md',
+  );
+
+  expect(
+    validateAgentDocContract({ ...validInput, repositoryEntries }),
+  ).toContain('Referenced path does not exist: .claude/rules/testing.md');
+});
+
+test('rejects empty or malformed boundary sections', () => {
+  const agents = replaceSection(
+    validInput.agents,
     DERIVATION_BEGIN,
     DERIVATION_END,
-  ];
-
-  expect(markers.map((marker) => countOccurrences(agents, marker))).toEqual([
-    1, 1, 1, 1,
-  ]);
-  expect(markers.map((marker) => agents.indexOf(marker))).toEqual(
-    markers.map((marker) => agents.indexOf(marker)).toSorted((a, b) => a - b),
-  );
-  expect(extractSection(agents, UNIVERSAL_BEGIN, UNIVERSAL_END)).not.toBe('');
-  expect(extractSection(agents, DERIVATION_BEGIN, DERIVATION_END)).not.toBe('');
-});
-
-test('the derivation-required section points agents to adapt-template', () => {
-  const agents = readRepositoryFile('AGENTS.md');
-  const derivationSection = extractSection(
-    agents,
-    DERIVATION_BEGIN,
-    DERIVATION_END,
+    '',
   );
 
-  expect(derivationSection).toContain('.claude/skills/adapt-template/SKILL.md');
-});
-
-test('adapt-template preserves the universal boundary and updates the derivation boundary', () => {
-  const skill = readRepositoryFile('.claude/skills/adapt-template/SKILL.md');
-
-  expect(skill).toContain(UNIVERSAL_BEGIN);
-  expect(skill).toContain(UNIVERSAL_END);
-  expect(skill).toContain(DERIVATION_BEGIN);
-  expect(skill).toContain(DERIVATION_END);
-  expect(skill).toMatch(
-    /universal section[^.]+(?:preserve|do not (?:edit|rewrite))/i,
-  );
-  expect(skill).toMatch(
-    /derivation-required section[^.]+(?:update|rewrite|delete)/i,
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Derivation-required section must not be empty.',
   );
 });
 
-test('CLAUDE.md imports AGENTS.md exactly once', () => {
-  const claude = readRepositoryFile('CLAUDE.md');
-  const imports = claude.match(/^@AGENTS\.md\s*$/gmu) ?? [];
+test('rejects overlapping or reordered top-level sections', () => {
+  const universalBlock = validInput.agents.slice(
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:BEGIN -->'),
+    validInput.agents.indexOf('<!-- AGENTS:UNIVERSAL:END -->') +
+      '<!-- AGENTS:UNIVERSAL:END -->'.length,
+  );
+  const derivationBlock = validInput.agents.slice(
+    validInput.agents.indexOf(DERIVATION_BEGIN),
+    validInput.agents.indexOf(DERIVATION_END) + DERIVATION_END.length,
+  );
 
-  expect(imports).toHaveLength(1);
+  expect(
+    validateAgentDocContract({
+      ...validInput,
+      agents: `${derivationBlock}\n\n${universalBlock}\n`,
+    }),
+  ).toContain(
+    'Universal and derivation-required sections must be ordered and non-overlapping.',
+  );
+});
+
+test('rejects shared-layer metadata that no longer matches src/lib', () => {
+  const agents = validInput.agents.replace('"messaging", ', '');
+
+  expect(validateAgentDocContract({ ...validInput, agents })).toContain(
+    'Shared-layer metadata must match src/lib/: expected messaging, storage, testing; received storage, testing.',
+  );
+});
+
+test('requires machine-readable skill and CLAUDE contract anchors', () => {
+  const skill = validInput.skill.replace(
+    '<!-- AGENTS-CONTRACT:DERIVATION:SYNCHRONIZE -->',
+    '',
+  );
+  const claude = validInput.claude.replace(
+    '<!-- AGENTS-CONTRACT:SINGLE-SOURCE -->',
+    '',
+  );
+
+  expect(validateAgentDocContract({ ...validInput, skill })).toContain(
+    'adapt-template must declare the derivation synchronization contract.',
+  );
+  expect(validateAgentDocContract({ ...validInput, claude })).toContain(
+    'CLAUDE.md must declare AGENTS.md as its single source of truth.',
+  );
 });

--- a/scripts/agent-doc-contract.test.mjs
+++ b/scripts/agent-doc-contract.test.mjs
@@ -317,6 +317,27 @@ test('keeps source directories whose basename matches a root-level ignore', () =
   }
 });
 
+test('ignores dependency and git directories at every depth', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agent-doc-contract-'));
+  try {
+    mkdirSync(join(root, 'packages', 'app', 'node_modules', 'lodash'), {
+      recursive: true,
+    });
+    mkdirSync(join(root, 'vendor', '.git', 'objects'), { recursive: true });
+    mkdirSync(join(root, 'src', 'lib', 'logs'), { recursive: true });
+    writeFileSync(
+      join(root, 'packages', 'app', 'node_modules', 'lodash', 'index.js'),
+      'dependency',
+    );
+    writeFileSync(join(root, 'vendor', '.git', 'objects', 'blob'), 'metadata');
+    writeFileSync(join(root, 'src', 'lib', 'logs', 'logger.ts'), 'source');
+
+    expect(collectRepositoryEntries(root)).toEqual(['src/lib/logs/logger.ts']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('rejects empty or malformed boundary sections', () => {
   const agents = replaceSection(
     validInput.agents,


### PR DESCRIPTION
## Summary

- `AGENTS.md` を機械判別可能な普遍区画と派生時更新必須区画へ分離
- 普遍区画を構成非依存の原則へ限定し、具体パス・lintルール・検証コマンドを派生区画へ集約
- 派生区画にsurface・共有層の機械可読metadataを追加
- `CLAUDE.md` と `adapt-template` を機械可読アンカーで契約へ同期
- 文書契約validatorと破壊的fixtureテストを追加

## Why

派生プロダクトでsurfaceや共有層を削除しても、AGENTS.mdにテンプレート構成が残り、AIエージェントへ恒久的な誤情報を与える問題がありました。普遍ルールと構成依存記述を分離するだけでなく、派生後に削除済み構成が残る失敗をテストで検出します。

## TDD

初回実装:

- Red: 境界マーカー未定義・adapt-template未連携の2件
- Green: 契約テスト4件成功

レビュー対応:

- Red: validator未実装、root-level stale path未検出
- Green: 契約テスト12件成功
- 再レビューRed: git非依存のファイル収集未実装
- 再レビューGreen: 契約テスト16件成功
- 再々レビューRed: スキル削除・非npmコマンド・root移設・生成物除外の5件失敗
- 再々レビューGreen: 契約テスト21件成功
- 最終レビューRed: nested source ignore・file root誤指定の2件失敗
- 最終レビューGreen: 契約テスト23件成功
- 承認後申し送りRed: 入れ子の `node_modules` / `.git` がrepository treeへ混入
- 承認後申し送りGreen: 契約テスト24件成功
- 検証対象:
  - 普遍区画のcanonical SHA-256不一致
  - マーカーの一意性・順序・非空
  - surface / shared-layer metadataと実ツリーの不一致
  - 削除済みrepository pathと存在しないroot document
  - 未定義npm script
  - npm/npxコマンドのpath誤判定防止
  - gitなし環境でのrepository tree収集
  - adapt-template / CLAUDEの機械可読アンカー
  - adapt-template削除後も継続する契約検証
  - metadata rootの実在と移設後ツリーの一致
  - 空白を含む非npmコマンドのpath誤判定防止
  - 生成物・local-only pathの走査除外
  - root-level ignoreと同名のnested source保持
  - metadata rootがrepository directoryであること
  - `.git` / `node_modules` の全階層除外とroot-level ignore同名sourceの保持

## Review fixes

- 完了ゲートの過大な主張を、実際のvalidator検証範囲へ修正
- universal区画から `src/lib/**`、`.oxlintrc.json`、具体lint rule名、React固有規約を除去
- universalは原則、derivationはリポジトリ固有実装として正典を分離
- 散文の単語ブラックリストを廃止し、パス・コマンド・metadataのみを機械検証
- `paths` / `commands` metadataを廃止し、散文中のliteralを直接検証
- npm/npxコマンドをpath判定から除外
- git依存を廃止し、filesystem走査をvalidator側へ実装
- adapt-templateを派生完了後に削除できるoptional契約へ変更
- entrypoint/shared rootをmetadata化し、移設と実在を検証
- 空白を含むcode spanをcommand候補としてpath判定から除外
- `dist`、cache、`.env`、log、package archive等をrepository走査から除外
- ignore適用をrepository root直下へ限定し、同名source directoryを保持
- `.git` / `node_modules` だけは全階層で除外し、モノレポやvendor配下の依存物・Git metadata混入を防止
- metadata rootの存在に加えてdirectory性を検証
- SHA不一致時にexpected/actual hashと算出対象を表示
- Markdown全体へのPrettier導入は行わず、表の整形のみの差分を戻した
- 一時領域の評価率は再現不能なためPR本文から削除

## Verification

- `npm test -- --run scripts/agent-doc-contract.test.mjs`: 24 passed
- `npm run verify`
  - Vitest: 15 files / 82 tests passed
  - build / manifest verification passed
- `npx prettier --check scripts/agent-doc-contract.mjs scripts/agent-doc-contract.test.mjs .claude/skills/adapt-template/SKILL.md`
- `git diff --check`

`verify:manifest` のテンプレート既定displayName警告は既存の意図した警告です。ランタイムAPI・TypeScript型・拡張挙動の変更はありません。

Closes #130